### PR TITLE
Address tech debt: fix timezones, remove any types, delete dead code

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web (Next.js)",
+      "runtimeExecutable": "/Users/ckuijjer/.nvm/versions/node/v22.22.1/bin/pnpm",
+      "runtimeArgs": ["--filter", "web-nextjs", "dev", "--turbopack"],
+      "port": 3000
+    }
+  ]
+}

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -1,0 +1,33 @@
+name: opencode
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  opencode:
+    if: |
+      contains(github.event.comment.body, ' /oc') ||
+      startsWith(github.event.comment.body, '/oc') ||
+      contains(github.event.comment.body, ' /opencode') ||
+      startsWith(github.event.comment.body, '/opencode')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run opencode
+        uses: anomalyco/opencode/github@latest
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        with:
+          model: anthropic/claude-sonnet-4-6

--- a/cloud/lib/backend-stack.ts
+++ b/cloud/lib/backend-stack.ts
@@ -45,7 +45,6 @@ export class BackendStack extends cdk.Stack {
         sourceMap: true,
         minify: true,
         metafile: true,
-        // externalModules: ['emitter', '@sparticuz/chromium'],
         externalModules: [
           'emitter',
           '@aws-sdk/client-dynamodb',
@@ -53,14 +52,6 @@ export class BackendStack extends cdk.Stack {
           '@aws-sdk/lib-dynamodb',
         ],
         nodeModules: ['@sparticuz/chromium'],
-        // format: lambdaNodejs.OutputFormat.ESM,
-        // Above unfortunately doesn't work yet, see error message below
-        // "Error: Dynamic require of \"http\" is not supported",
-        // "    at file:///var/task/index.mjs:1:436",
-        // "    at PacProxyAgent (/node_modules/.pnpm/proxy-agent@6.5.0/node_modules/proxy-agent/src/index.ts:1:1)",
-        // "    at file:///var/task/index.mjs:1:548",
-        // "    at <anonymous> (/node_modules/.pnpm/@puppeteer+browsers@2.7.1/node_modules/@puppeteer/browsers/src/httpUtil.ts:12:26)",
-        // "    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)",
       },
       environment: {
         ...DEFAULT_FUNCTION_ENVIRONMENT_PROPS,
@@ -95,13 +86,6 @@ export class BackendStack extends cdk.Stack {
       },
     )
 
-    // Scrapers
-    const chromeAwsLambdaLayer = lambda.LayerVersion.fromLayerVersionArn(
-      this,
-      'scrapers-lambda-layer',
-      'arn:aws:lambda:eu-west-1:764866452798:layer:chrome-aws-lambda:50',
-    )
-
     // TODO: Fix the issue with bundling (likely see scrapers.ts and scrapers/index.ts)
     const scrapersLambda = new lambdaNodejs.NodejsFunction(
       this,
@@ -129,7 +113,6 @@ export class BackendStack extends cdk.Stack {
           SCRAPERS: config.SCRAPERS,
           SCRAPEOPS_API_KEY: config.SCRAPEOPS_API_KEY,
         },
-        // layers: [chromeAwsLambdaLayer],
       },
     )
 
@@ -177,7 +160,6 @@ export class BackendStack extends cdk.Stack {
           SCRAPERS: config.SCRAPERS,
           SCRAPEOPS_API_KEY: config.SCRAPEOPS_API_KEY,
         },
-        // layers: [chromeAwsLambdaLayer],
       },
     )
 

--- a/cloud/metadata/searchMetadata.ts
+++ b/cloud/metadata/searchMetadata.ts
@@ -1,22 +1,26 @@
 import leven from 'leven'
 
-import getDuckDuckGoClient from '../clients/duckduckgo'
 import getGoogleCustomSearchClient from '../clients/google-customsearch'
-import getOmdbClient from '../clients/omdb'
 import getTmdbClient from '../clients/tmdb'
 import { logger } from '../powertools'
 import { removeDiacritics } from '../scrapers/utils/removeDiacritics'
+
+type TmdbMovieResult = { id: number; title?: string; originalTitle?: string; [key: string]: unknown }
+type TmdbSearchResponse = { results: TmdbMovieResult[] }
+type TmdbFindResponse = { movieResults: TmdbMovieResult[] }
+type GoogleSearchItem = { title: string; pagemap: { metatags: Array<Record<string, string>> } }
+type GoogleSearchResponse = { items?: GoogleSearchItem[] }
 
 const getFirstTmdbSearchResult = async (title: string) => {
   const apiKey = process.env.TMDB_API_KEY
 
   const tmdb = getTmdbClient(apiKey)
 
-  const { results }: any = await tmdb.get('search/movie', {
+  const { results } = (await tmdb.get('search/movie', {
     searchParams: {
       query: title,
     },
-  })
+  })) as TmdbSearchResponse
 
   if (results?.length > 0) {
     return {
@@ -31,45 +35,14 @@ const getTmdbUsingImdbId = async (imdbId: string) => {
 
   const tmdb = getTmdbClient(apiKey)
 
-  const { movieResults }: any = await tmdb.get(`find/${imdbId}`, {
+  const { movieResults } = (await tmdb.get(`find/${imdbId}`, {
     searchParams: {
       external_source: 'imdb_id',
     },
-  })
+  })) as TmdbFindResponse
 
   const movie = movieResults?.[0]
   return movie
-}
-
-const getFirstOmdbSearchResult = async (title: string) => {
-  const apiKey = process.env.OMDB_API_KEY
-
-  const omdb = getOmdbClient(apiKey)
-
-  const result = await omdb.get({
-    searchParams: { t: title, type: 'movie' },
-  })
-
-  return result
-}
-
-const getFirstDuckDuckGoResult = async (title: string) => {
-  const duckDuckGo = getDuckDuckGoClient()
-
-  const result: any = await duckDuckGo.get({
-    searchParams: {
-      q: title,
-    },
-  })
-
-  if (result.entity === 'film') {
-    return {
-      title: result.heading,
-      imdbId: result.infobox.content.find(
-        ({ dataType }) => dataType === 'imdb_id',
-      )?.value,
-    }
-  }
 }
 
 const getFirstGoogleCustomSearchResult = async (title: string) => {
@@ -81,11 +54,11 @@ const getFirstGoogleCustomSearchResult = async (title: string) => {
     apiKey,
   })
 
-  const result: any = await googleCustomSearch.get({
+  const result = (await googleCustomSearch.get({
     searchParams: {
       q: title,
     },
-  })
+  })) as GoogleSearchResponse
 
   if (result.items?.length > 0) {
     return {
@@ -99,15 +72,11 @@ const searchMetadata = async (title: string) => {
   const normalizedTitle = removeDiacritics(title.toLowerCase())
 
   const tmdb = await getFirstTmdbSearchResult(normalizedTitle)
-  // const omdb = await getFirstOmdbSearchResult(normalizedTitle)  // OMDB throws 500 errors
-  // const duckduckgo = await getFirstDuckDuckGoResult(normalizedTitle)
   const googleCustomSearch =
     await getFirstGoogleCustomSearchResult(normalizedTitle)
 
   const firstSearchResults = Object.entries({
     tmdb,
-    // omdb, // OMDB throws 500 errors
-    // duckduckgo,
     googleCustomSearch,
   }).map(([name, value]) => ({ name, imdbId: value?.imdbId ?? null }))
 

--- a/cloud/scrapers/cinecenter.ts
+++ b/cloud/scrapers/cinecenter.ts
@@ -83,10 +83,6 @@ if (
   extractFromMainPage()
     .then((x) => JSON.stringify(x, null, 2))
     .then(console.log)
-  //   extractFromMoviePage({
-  // url: 'https://cinecenter.nl/film/cine-expat-woman/?special=expat',
-  // url: 'https://cinecenter.nl/film/cine-expat-system-crasher/?special=expat',
-  //   })
 }
 
 export default extractFromMainPage

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -10,11 +10,6 @@ import documentClient from '../documentClient'
 import getMetadata from '../metadata'
 import { logger } from '../powertools'
 import { Screening } from '../types'
-// TODO: esbuild doesn't support dynamic import, hence all the imports below
-// SCRAPERS.map(async (name) => {
-//   const fn = await import(`./${name}`)
-//   return [name, sort(await fn())]
-// }),
 import bioscopenleiden from './bioscopenleiden'
 import cinecenter from './cinecenter'
 import cinecitta from './cinecitta'
@@ -38,7 +33,6 @@ import kriterion from './kriterion'
 import lab1 from './lab1'
 import lab111 from './lab111'
 import lantarenvenster from './lantarenvenster'
-import liff from './liff'
 import lumiere from './lumiere'
 import lux from './lux'
 import melkweg from './melkweg'
@@ -76,7 +70,6 @@ const SCRAPERS = {
   lab1,
   lab111, // uses puppeteer
   lantarenvenster,
-  // liff,
   lumiere, // uses puppeteer
   lux,
   melkweg,

--- a/cloud/scrapers/kriterion.ts
+++ b/cloud/scrapers/kriterion.ts
@@ -126,10 +126,6 @@ const extractFromMainPage = async () => {
       .filter((item) => /\(eng subs\)/i.test(item.name))
       .map((item) => {
         const slug = productionIdToSlug[item.production_id]
-        // .replace(
-        //   /-eng-subs/,
-        //   '',
-        // )
         const url = `https://kriterion.nl/films/${slug}`
 
         const screening: Screening = {
@@ -165,10 +161,6 @@ if (
   extractFromMainPage()
     .then((x) => JSON.stringify(x, null, 2))
     .then(console.log)
-
-  // extractFromMoviePage({
-  //   url: 'https://kriterion.nl/films/dogman',
-  // }).then(console.log)
 }
 
 export default extractFromMainPage

--- a/web/components/Statistics.tsx
+++ b/web/components/Statistics.tsx
@@ -77,8 +77,6 @@ const Tile = ({
 }
 
 export const Statistics = ({ points }: { points: AnalyticsPoint[] }) => {
-  console.log({ points })
-
   const [highlight, setHighlight] = React.useState<string | null>(null)
 
   const sortedPoints = [...points].sort((a, b) => {

--- a/web/components/Time.tsx
+++ b/web/components/Time.tsx
@@ -3,10 +3,11 @@ import React from 'react'
 
 export class Time extends React.PureComponent<{ children: DateTime }> {
   render() {
-    // TODO: Format in the Europe/Amsterdam timezone with English locale here
     return (
       <div style={{ fontSize: 18 }}>
-        {this.props.children.toLocaleString(DateTime.TIME_24_SIMPLE)}
+        {this.props.children
+          .setZone('Europe/Amsterdam')
+          .toLocaleString(DateTime.TIME_24_SIMPLE, { locale: 'en-GB' })}
       </div>
     )
   }

--- a/web/utils/groupAndSortScreenings.ts
+++ b/web/utils/groupAndSortScreenings.ts
@@ -5,8 +5,6 @@ import { getToday } from './getToday'
 
 export type ScreeningWithLuxonDate = Omit<Screening, 'date'> & { date: DateTime }
 
-// TODO: The grouping should be based on the Europe/Amsterdam timezone
-
 // sort the screenings by date and time
 // group by date
 // inject some dates? e.g. the coming week? by doing an intersection with a static list of coming days?
@@ -22,7 +20,7 @@ export const groupAndSortScreenings = (
   // Group by ISO date string (Object.groupBy requires Node 21+)
   return sorted.reduce<Partial<Record<string, ScreeningWithLuxonDate[]>>>(
     (acc, x) => {
-      const key = x.date.toISODate() ?? ''
+      const key = x.date.setZone('Europe/Amsterdam').toISODate() ?? ''
       acc[key] = [...(acc[key] ?? []), x]
       return acc
     },


### PR DESCRIPTION
## Summary

- **Fix timezone bugs**: `groupAndSortScreenings` now uses `Europe/Amsterdam` when computing the date key (late-night screenings no longer land on the wrong day); `Time` component now renders in the correct timezone with `en-GB` locale
- **Remove `console.log`** left in `Statistics.tsx` (production debug leak)
- **Replace `any` types** in `searchMetadata.ts` with minimal typed interfaces (`TmdbSearchResponse`, `TmdbFindResponse`, `GoogleSearchResponse`)
- **Delete dead code**: unused `getFirstOmdbSearchResult` + `getFirstDuckDuckGoResult` functions and their imports; unused `chromeAwsLambdaLayer` variable and commented-out blocks in `backend-stack.ts`; commented-out esbuild dynamic import block; unused `liff` import and entry; stale commented-out debug calls in `cinecenter` and `kriterion`

## Test plan

- [ ] Verify the web app renders correctly and times display in 24h Amsterdam time
- [ ] Check screenings near midnight are grouped under the correct date
- [ ] Confirm no TypeScript errors: `pnpm type-check` in `web/` and `cloud/`
- [ ] Confirm cloud tests still pass: `cd cloud && pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)