### PR TITLE
Fix Lab-1 scraper stripping 'Laatste kans!' badge from titles

### DIFF
--- a/cloud/scrapers/lab1.ts
+++ b/cloud/scrapers/lab1.ts
@@ -95,6 +95,7 @@ type ScreeningEvent = {
 const cleanTitle = (title: string) =>
   titleCase(
     title // e.g. Nordic Watching: Unruly (English subtitled)
+      .replace(/\s*Laatste kans!/i, '') // e.g. <sup>Laatste kans!</sup> badge
       .replace(/\s+\(.*?\)$/i, '') // e.g. (English subtitled)
       .replace(/^.*?:\s+/, ''), // e.g. Nordic Watching:
   )


### PR DESCRIPTION
## Summary
- The `<sup>Laatste kans!</sup>` badge inside `<h3><a>` was being concatenated into the movie title (e.g. `Mr. Nobody against PutinLaatste kans!`)
- Added a `.replace(/\s*Laatste kans!/i, '')` step in `cleanTitle` to strip the badge text before further cleaning

## Test plan
- [x] Ran `LOG_LEVEL=debug pnpm tsx scrapers/lab1.ts` locally and confirmed `Mr. Nobody against Putin` is extracted cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)