### PR TITLE
Fix Rialto scraper stripping '- Eng Subs' suffix from titles

### DIFF
--- a/cloud/scrapers/rialto.ts
+++ b/cloud/scrapers/rialto.ts
@@ -22,7 +22,7 @@ const xray = Xray({
     trim,
     cleanTitle: (value) =>
       typeof value === 'string'
-        ? titleCase(value.replace(' - Expat Cinema', ''))
+        ? titleCase(value.replace(/ - (Expat Cinema|Eng Subs)/i, ''))
         : value,
   },
 })


### PR DESCRIPTION
## Summary
- Rialto appends `- Eng Subs` to film titles (e.g. `Mr. Nobody Against Putin - Eng Subs`)
- Extended the existing `cleanTitle` regex to strip both `- Expat Cinema` and `- Eng Subs` suffixes

## Test plan
- [x] Ran `LOG_LEVEL=debug pnpm tsx scrapers/rialto.ts` locally and confirmed titles like `Mr. Nobody Against Putin`, `The Secret Agent`, `L'étranger` are extracted cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)