### PR TITLE
Fix Schuur scraper stripping '- English Subs' suffix from titles

### DIFF
--- a/cloud/scrapers/schuur.ts
+++ b/cloud/scrapers/schuur.ts
@@ -22,7 +22,7 @@ const xray = Xray({
     trim,
     cleanTitle: (value) =>
       typeof value === 'string'
-        ? titleCase(value.replace(/^Expat Cinema:\s+/i, ''))
+        ? titleCase(value.replace(/^Expat Cinema:\s+/i, '').replace(/ - English subs$/i, ''))
         : value,
     normalizeWhitespace: (value) =>
       typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,


### PR DESCRIPTION
## Summary
- Schuur appends `- English Subs` to film titles (e.g. `Il Conformista - English Subs`)
- Extended the existing `cleanTitle` regex to also strip `- English subs` suffixes

## Test plan
- [x] Ran `pnpm tsx scrapers/schuur.ts` locally

**Before:** `Il Conformista - English Subs`, `La Grazia - English Subs`, `Joe Speedboot - English Subs`, ...
**After:** `Il Conformista`, `La Grazia`, `Joe Speedboot`, ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)