### PR TITLE
Use Node 24 built-ins: Object.groupBy in groupAndSortScreenings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Session Setup
 
-**Always run `nvm use` at the start of every session** to activate Node 22 (as specified in `.nvmrc`). This ensures the correct Node version is used for all commands.
+**Always run `nvm use` at the start of every session** to activate Node 24 (as specified in `.nvmrc`). This ensures the correct Node version is used for all commands.
 
 ```bash
 nvm use
@@ -31,7 +31,7 @@ expatcinema.com/
 
 **Cloud (Backend)**
 
-- **Runtime:** Node.js 22 (AWS Lambda)
+- **Runtime:** Node.js 24 (AWS Lambda)
 - **Infrastructure:** AWS CDK (TypeScript)
 - **Storage:** S3 (data), DynamoDB (metadata cache, analytics)
 - **Web Scraping:** Puppeteer (headless Chrome), got (HTTP), x-ray (HTML parsing)
@@ -41,7 +41,7 @@ expatcinema.com/
 
 **Web (Frontend)**
 
-- **Framework:** Next.js 15 with static export (`output: 'export'`)
+- **Framework:** Next.js 16 with static export (`output: 'export'`)
 - **Styling:** Emotion (CSS-in-JS)
 - **UI:** React 19 with react-virtualized for performance
 - **Visualization:** Observable Plot
@@ -50,9 +50,9 @@ expatcinema.com/
 **Development Tools**
 
 - **Package Manager:** pnpm 9.15.4 (defined in packageManager field)
-- **Node Version:** 22 (see .nvmrc)
-- **TypeScript:** 5.8.2
-- **Code Formatting:** Prettier with import sorting plugin
+- **Node Version:** 24 (see .nvmrc)
+- **TypeScript:** 5.9.3
+- **Code Formatting:** Prettier
 - **CI/CD:** GitHub Actions
 
 ## Core Data Model
@@ -388,7 +388,7 @@ const screening: Screening = {
 **Scrapers Lambda:**
 
 - **Name:** `expatcinema-{stage}-scrapers`
-- **Runtime:** Node.js 22, x86_64
+- **Runtime:** Node.js 24, x86_64
 - **Memory:** 1024 MB
 - **Timeout:** 1 minute (configurable per function)
 - **Layers:** Chrome AWS Lambda layer (for Puppeteer)
@@ -575,13 +575,9 @@ $('#voorstellingen .wp-block-group:has(> .datum-tekst)')
 
 SVG icons in `web/components/icons/` are plain TSX components (e.g. `SearchIcon.tsx`, `CrossIcon.tsx`, `MenuIcon.tsx`). They accept `React.SVGProps<SVGSVGElement>` props. Do not use `.svg` file imports — there is no SVGR loader configured.
 
-### Turbopack: `Object.groupBy` Not Available in SSR Sandbox
+### Node 24 Built-ins Available in SSR
 
-**Problem:** `TypeError: Object.groupBy is not a function` at runtime even when running Node 22 locally.
-
-**Cause:** Turbopack's SSR sandbox runs in an environment where `Object.groupBy` (Node 21+) is not available.
-
-**Solution:** Use `reduce` or `flatMap` instead of `Object.groupBy` in any code that runs during SSR.
+`Object.groupBy` and other Node 21+ built-ins are available in Turbopack's SSR sandbox as of Next.js 16 + Node 24. Use them freely — no need to fall back to `reduce` or `flatMap`.
 
 ### Monorepo: Don't Rely on Transitive `@types/*` Packages
 

--- a/web/utils/groupAndSortScreenings.ts
+++ b/web/utils/groupAndSortScreenings.ts
@@ -19,13 +19,8 @@ export const groupAndSortScreenings = (
     .filter((x) => x.date >= getToday())
     .sort((a, b) => a.date.toMillis() - b.date.toMillis())
 
-  // Group by ISO date string (Object.groupBy requires Node 21+)
-  return sorted.reduce<Partial<Record<string, ScreeningWithLuxonDate[]>>>(
-    (acc, x) => {
-      const key = x.date.setZone('Europe/Amsterdam').toISODate() ?? ''
-      acc[key] = [...(acc[key] ?? []), x]
-      return acc
-    },
-    {},
+  return Object.groupBy(
+    sorted,
+    (x) => x.date.setZone('Europe/Amsterdam').toISODate() ?? '',
   )
 }


### PR DESCRIPTION
## Summary

Uses `Object.groupBy` (Node 21+) in `groupAndSortScreenings.ts`, replacing a `reduce` workaround that was added because the Turbopack SSR sandbox previously didn't expose it.

Confirmed working in Next.js 16 + Node 24 — no SSR errors, calendar renders correctly.

Also updates `CLAUDE.md` to reflect the current stack:
- Node 22 → 24 throughout
- Next.js 15 → 16
- TypeScript 5.8.2 → 5.9.3
- Removed trivago prettier plugin mention (already removed)
- Replaced `Object.groupBy` SSR warning with confirmation it now works

## Test plan

- [x] Dev server started, page loads with no console errors
- [x] Calendar renders correctly (uses `groupAndSortScreenings` for SSR)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — 19 pages generated successfully
- [x] `pnpm format` — no unformatted files
- [x] `npx tsc --noEmit` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)