### PR TITLE
Remove stale bin entry from cloud/package.json

### DIFF
--- a/cloud/package.json
+++ b/cloud/package.json
@@ -2,9 +2,6 @@
   "name": "expatcinema.com-cloud",
   "version": "1.0.1",
   "description": "",
-  "bin": {
-    "backend": "bin/backend.js"
-  },
   "type": "module",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
## Summary
- Removes the `bin.backend` field from `cloud/package.json` that pointed to a non-existent `bin/backend.js`
- This was a CDK scaffold leftover causing `pnpm install` to emit `WARN Failed to create bin at .../backend` warnings

## Test plan
- [x] Run `pnpm i` and confirm no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)