### PR TITLE
Fix The Movies scraper language label check

### DIFF
--- a/cloud/scrapers/themovies.ts
+++ b/cloud/scrapers/themovies.ts
@@ -29,7 +29,7 @@ const hasEnglishSubtitles = (
 
 const hasEnglishSubtitlesLabel = (movie: FkFeedItem) => {
   return (
-    movie.language.label === 'Ondertiteling' &&
+    movie.language.label === 'Ondertitels' &&
     (movie.language.value === 'Engels' || movie.language.value === 'English')
   )
 }


### PR DESCRIPTION
## Summary
- The `hasEnglishSubtitlesLabel` check used `label === 'Ondertiteling'` but the themovies API (same fk-feed format as Filmkoepel) returns `label: 'Ondertitels'` for all movies
- This meant the label-based check never matched, so English-subtitled films would not be detected via that path
- Fixed to use `'Ondertitels'` to match the actual API response (consistent with the Filmkoepel scraper)

## Test plan
- [x] Run `LOG_LEVEL=info pnpm tsx scrapers/themovies.ts` from `cloud/` — scraper runs without errors (currently 0 screenings since no English-subtitled films are scheduled, which is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)