### PR TITLE
Fix Concordia scraper for redesigned website

### DIFF
--- a/cloud/scrapers/concordia.ts
+++ b/cloud/scrapers/concordia.ts
@@ -1,10 +1,10 @@
+import { decode } from 'html-entities'
 import { DateTime } from 'luxon'
 import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
-import { guessYear } from './utils/guessYear'
-import { monthToNumber } from './utils/monthToNumber'
+import { shortMonthToNumberDutch } from './utils/monthToNumber'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -16,11 +16,6 @@ const logger = parentLogger.createChild({
   },
 })
 
-type XRayFromMainPage = {
-  url: string
-  title: string
-}
-
 const xray = Xray({
   filters: {
     trim,
@@ -29,107 +24,57 @@ const xray = Xray({
   .concurrency(10)
   .throttle(10, 300)
 
-// dinsdag 24 sep.
-// maandag 14 okt.
-const parseDate = (date: string) => {
-  if (date === 'Vandaag') {
-    const { day, month, year } = DateTime.now()
-    return { day, month, year }
-  } else if (date === 'Morgen') {
-    const { day, month, year } = DateTime.now().plus({ days: 1 })
-    return { day, month, year }
-  } else if (/^[0-9]{2}-[0-9]{2}-[0-9]{4}$/.test(date)) {
-    // 10-10-2024
-    // 30-09-2024
-    const [dayString, monthString, yearString] = date.split('-')
-    const day = Number(dayString)
-    const month = Number(monthString)
-    const year = Number(yearString)
-
-    return { day, month, year }
-  } else {
-    // b.v. ma 11.12
-    const [dayOfWeek, dayString, monthString] = date.split(/ |\./) // space or dot
-
-    const day = Number(dayString)
-    const month = monthToNumber(monthString)
-    const year = guessYear({ day, month })
-
-    return { day, month, year }
-  }
+type XRayScreening = {
+  date: string
+  title: string
+  url: string
+  times: string[]
 }
 
-const hasEnglishSubtitles = (metadata) => metadata.Ondertiteling === 'ENG'
+// e.g. "21 mrt 2026" -> { day: 21, month: 3, year: 2026 }
+const parseDate = (date: string) => {
+  const [dayString, monthString, yearString] = date.split(' ')
+  const day = Number(dayString)
+  const month = shortMonthToNumberDutch(monthString)
+  const year = Number(yearString)
+  return { day, month, year }
+}
 
-const extractFromMoviePage = async (url: string): Promise<Screening[]> => {
-  logger.info('extracting movie page', { url })
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  logger.info('extracting main page')
 
-  const xrayResult = await xray(url, {
-    title: 'section .col-span-full .offer-detail-header-caption h1',
-    screenings: xray(
-      'section .col-span-full .relative.py-6 > .grid > div > div, .relative.py-6',
-      [
-        {
-          date: 'span.p--small:not(:has(button)) | trim',
-          times: ['> div > a > span:first-child | trim'],
-        },
-      ],
-    ),
-    sidebarButton: 'button.link[data-target="offerTimes"]',
-    sidebarScreenings: xray('[data-id="offerTimes"] > div > div > div', [
+  const results: XRayScreening[] = await xray(
+    'https://www.concordia.nl/eng-subs',
+    'div.film.OverviewListItem',
+    [
       {
-        date: 'span.p--small:not(:has(button)) | trim',
-        times: ['a > span:first-child | trim'],
+        date: 'li.label | trim',
+        title: 'h4.heading-4.event-title a | trim',
+        url: 'h4.heading-4.event-title a@href',
+        times: ['span.big | trim'],
       },
-    ]),
-    metadata: xray('section .col-span-full .hidden .grid .flex', [
-      {
-        key: 'span | trim',
-        value: '@text | trim', // contains both the key and the value, @text:not(:has(span)) or @text:not(span) doesn't work
-      },
-    ]),
-  })
+    ],
+  )
 
-  // if (
-  //   xrayResult.screenings.length === 0 ||
-  //   xrayResult.sidebarScreenings.length === 0 ||
-  //   xrayResult.metadata.length === 0
-  // ) {
-  //   logger.error('No movies found on movie page, scraper is probably broken', {
-  //     url,
-  //     xrayResult,
-  //   })
-  // }
+  logger.info('main page', { results })
 
-  //   fix metadata by taking of the key from the value
-  const metadata = xrayResult.metadata.reduce((acc, { key, value }) => {
-    acc[key] = value
-      .replace(key, '') // remove the key from the value
-      .replace(/\n/g, '') // remove all newlines
-      .replace(/\s{2,}/g, ' ') // convert all double spaces (or more) to single space
-      .trim()
-    return acc
-  }, {})
+  if (results.length === 0) {
+    logger.error('No screenings found on main page, scraper is probably broken')
+    return []
+  }
 
-  if (!hasEnglishSubtitles(metadata)) return []
+  const screenings = results
+    .filter(({ date, times }) => date && times.length > 0)
+    .flatMap(({ date, title, url, times }) => {
+      const { day, month, year } = parseDate(date)
 
-  // For some pages with English subtitled screenings, the sidebar is hidden and not accessible (it contains the regular non English subtitled screenings)
-  const scrapedScreenings = xrayResult.sidebarButton
-    ? xrayResult.sidebarScreenings
-    : xrayResult.screenings
-
-  const screenings = scrapedScreenings
-    .filter(({ date, times }) => {
-      return date && times.length > 0 // remove the movies that don't have a screening time (yet)
-    })
-    .flatMap(({ date, times }) => {
       return times.map((time) => {
-        const { day, month, year } = parseDate(date)
         const [hour, minute] = splitTime(time)
 
         return {
-          title: titleCase(xrayResult.title),
+          title: titleCase(decode(title)),
           url,
+          cinema: 'Concordia',
           date: DateTime.fromObject({
             day,
             month,
@@ -137,50 +82,13 @@ const extractFromMoviePage = async (url: string): Promise<Screening[]> => {
             hour,
             minute,
           }).toJSDate(),
-          cinema: 'Concordia',
         }
       })
     })
 
+  logger.info('screenings', { screenings })
+
   return screenings
-}
-
-const extractFromMainPage = async (): Promise<Screening[]> => {
-  logger.info('extracting main page')
-
-  const xrayResult: XRayFromMainPage[] = await xray(
-    'https://www.concordia.nl/film',
-    '#offerList div div',
-    [
-      {
-        url: 'div div a@href',
-        title: 'a h4 | trim',
-      },
-    ],
-  )
-
-  const uniqueUrls = Array.from(
-    new Set(
-      xrayResult
-        .map((x) => x.url)
-        .filter(
-          (url) => url !== undefined && url !== 'https://www.concordia.nl/film',
-        ),
-    ),
-  )
-
-  logger.info('main page', { uniqueUrls })
-
-  if (uniqueUrls.length === 0) {
-    logger.error('No movies found on main page, scraper is probably broken')
-    return []
-  }
-
-  const screenings = await Promise.all(uniqueUrls.map(extractFromMoviePage))
-
-  logger.info('before flatten', { screenings })
-
-  return screenings.flat()
 }
 
 runIfMain(extractFromMainPage, import.meta.url)


### PR DESCRIPTION
## Summary
- The concordia.nl website was redesigned (now Nuxt.js); the old `#offerList` selector no longer exists and the scraper returned 0 movies
- Rewrote the scraper to use the dedicated eng-subs page at `https://www.concordia.nl/eng-subs` which lists all English-subtitled screenings with SSR content
- Simplified: each film card on that page includes the date, title, URL, and screening time inline — no need to visit individual movie pages or check metadata

## Test plan
- [ ] Run `LOG_LEVEL=info pnpm tsx scrapers/concordia.ts` from `cloud/` — should find 7 screenings (as of 2026-03-21): No Other Choice, The Secret Agent, Joe Speedboot, Kiki's Delivery Service ×2, La Grazia, Il Conformista

🤖 Generated with [Claude Code](https://claude.com/claude-code)