### PR TITLE
Fix Cinecenter scraper for rebuilt website

### DIFF
--- a/cloud/scrapers/cinecenter.ts
+++ b/cloud/scrapers/cinecenter.ts
@@ -1,10 +1,10 @@
-import { DateTime } from 'luxon'
-import Xray from 'x-ray'
+import got from 'got'
+import { decode as decodeHtmlEntities } from 'html-entities'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { runIfMain } from './utils/runIfMain'
-import { trim } from './utils/xrayFilters'
+import { titleCase } from './utils/titleCase'
 
 const logger = parentLogger.createChild({
   persistentLogAttributes: {
@@ -12,70 +12,78 @@ const logger = parentLogger.createChild({
   },
 })
 
-const xray = Xray({
-  filters: {
-    trim,
-  },
-})
-  .concurrency(10)
-  .throttle(10, 300)
+const ENG_SUBS_TAG_NAME = 'Eng Subs'
+const ENG_SUBS_TITLE_PREFIX = /^Eng Subs:\s*/i
 
-const cleanTitle = (title: string) =>
-  title.replace(/Cine Expat: /i, '').replace(/^ENG SUBS: /i, '')
-
-type XRayFromMoviePage = {
-  title: string
-  showings: number[]
+// Decode Astro's serialization format used in astro-island props:
+// [0, value]     → primitive/object value
+// [1, [...]]     → array (items recursively decoded)
+// [3, isoString] → Date
+const decodeAstro = (val: unknown): unknown => {
+  if (val === null || typeof val !== 'object') return val
+  if (Array.isArray(val)) {
+    const [type, inner] = val as [number, unknown]
+    if (type === 0) return decodeAstro(inner)
+    if (type === 1) return (inner as unknown[]).map(decodeAstro)
+    if (type === 3) return new Date(inner as string)
+    return val
+  }
+  // Plain object — decode each value recursively
+  return Object.fromEntries(
+    Object.entries(val as Record<string, unknown>).map(([k, v]) => [
+      k,
+      decodeAstro(v),
+    ]),
+  )
 }
 
-const extractFromMoviePage = async ({ url }: { url: string }) => {
-  logger.info('extracting', { url })
-
-  const movie: XRayFromMoviePage = await xray(url, 'body', {
-    title: 'h1.film_title',
-    showings: [
-      '.tickets .collapse:not([id=cinedinerkaarten]) a[data-timestamp]@data-timestamp',
-    ],
-  })
-
-  logger.info('extracted xray', { url, movie })
-
-  const result = movie.showings.map((showing) => ({
-    title: cleanTitle(movie.title),
-    url,
-    cinema: 'Cinecenter',
-    date: DateTime.fromMillis(showing * 1000, { zone: 'utc' })
-      // the `showing` is in ms Amsterdam time, this way I try to hack the time back to UTC
-      // wonder however if this is correct for times where it's close to midnight (and crosses a day boundary)
-      .setZone('Europe/Amsterdam', { keepLocalTime: true })
-      .toUTC(),
-  }))
-
-  logger.info('extracting done', { url, result })
-
-  return result
+type CinecenterScreening = {
+  startAtUtc: Date
 }
 
-type XRayFromMainPage = {
+type CinecenterProduction = {
   title: string
-  url: string
+  slug: string
+  tags: Array<{ id: string; name: string }>
+  screenings: CinecenterScreening[]
 }
 
 const extractFromMainPage = async (): Promise<Screening[]> => {
-  const movies: XRayFromMainPage[] = await xray(
-    'https://cinecenter.nl/film/?expat=true',
-    'a.film-link',
-    [
-      {
-        title: 'h3.entry-title',
-        url: '@href',
-      },
-    ],
-  )
+  logger.info('extracting main page')
 
-  logger.info('main page', { movies })
+  const html = await got('https://cinecenter.nl/films/').text()
 
-  return (await Promise.all(movies.map(extractFromMoviePage))).flat()
+  const islandMatch = html.match(/astro-island[^>]*\sprops="([^"]+)"/)
+  if (!islandMatch) {
+    logger.error('No astro-island props found, scraper is probably broken')
+    return []
+  }
+
+  const propsStr = islandMatch[1].replace(/&quot;/g, '"').replace(/&amp;/g, '&')
+  const props = JSON.parse(propsStr)
+  const productions = decodeAstro(props.productions) as CinecenterProduction[]
+
+  logger.info('productions found', { count: productions.length })
+
+  const screenings: Screening[] = productions
+    .filter((p) => p.tags.some((t) => t.name === ENG_SUBS_TAG_NAME))
+    .flatMap((p) => {
+      const title = titleCase(
+        decodeHtmlEntities(p.title.replace(ENG_SUBS_TITLE_PREFIX, '')),
+      )
+      const url = `https://cinecenter.nl/films/${p.slug}/`
+
+      return p.screenings.map((s) => ({
+        title,
+        url,
+        cinema: 'Cinecenter',
+        date: s.startAtUtc,
+      }))
+    })
+
+  logger.info('screenings', { screenings })
+
+  return screenings
 }
 
 runIfMain(extractFromMainPage, import.meta.url)


### PR DESCRIPTION
## Summary
- The cinecenter.nl website was rebuilt with Astro + Vue SPA; the old `?expat=true` URL filter and `a.film-link` CSS selectors no longer exist
- The new site embeds all productions data as SSR props in an `astro-island` element — no Puppeteer needed
- Productions tagged `"Eng Subs"` are the English-subtitled films, with their screenings (including UTC start times) included inline
- Rewrote the scraper to fetch `/films/`, decode Astro's serialization format, and filter by the `Eng Subs` tag

## Test plan
- [ ] Run `LOG_LEVEL=info pnpm tsx scrapers/cinecenter.ts` from `cloud/` — should find 19 screenings across 6 films (as of 2026-03-21): Sirat, Amrum, No Other Choice, The Secret Agent, La Grazia, L'Étranger

🤖 Generated with [Claude Code](https://claude.com/claude-code)