### PR TITLE
Improve page titles and canonical URLs for city and cinema pages

### DIFF
--- a/web/components/Seo.tsx
+++ b/web/components/Seo.tsx
@@ -4,8 +4,14 @@ import React from 'react'
 const DESCRIPTION = 'Foreign movies with English subtitles'
 const AUTHOR = 'Expat Cinema'
 
-export const SEO = ({ title }: { title: string }) => {
-  const fullTitle = title ? `${title} | Expat Cinema` : 'Expat Cinema'
+export const SEO = ({
+  title,
+  canonical = 'https://expatcinema.com',
+}: {
+  title?: string
+  canonical?: string
+}) => {
+  const fullTitle = title ? `${title} \u2013 Expat Cinema` : 'Expat Cinema'
 
   return (
     <Head>
@@ -31,7 +37,7 @@ export const SEO = ({ title }: { title: string }) => {
       />
       <link rel="preconnect" href="https://www.google-analytics.com" />
       <link rel="dns-prefetch" href="https://www.google-analytics.com" />
-      <link rel="canonical" href="https://expatcinema.com" />
+      <link rel="canonical" href={canonical} />
       <link rel="icon" href="/favicon.ico" />
     </Head>
   )

--- a/web/pages/city/[city]/cinema/[cinema].tsx
+++ b/web/pages/city/[city]/cinema/[cinema].tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { App } from '../../../../components/App'
 import { SEO } from '../../../../components/Seo'
 import cinemas from '../../../../data/cinema.json'
+import { getCinema } from '../../../../utils/getCinema'
 import { Screening, getScreenings } from '../../../../utils/getScreenings'
 
 export const getStaticPaths = () => {
@@ -27,12 +28,17 @@ export const getStaticProps = async ({
       screening.cinema.city.name.toLowerCase() === city &&
       screening.cinema.slug === cinema,
   )
+  const cinemaData = getCinema(cinema)
+  const cinemaName = cinemaData?.name ?? cinema
+  const cityName = cinemaData?.city ?? city
 
   return {
     props: {
       data: screenings,
       city,
       cinema,
+      cinemaName,
+      cityName,
     },
   }
 }
@@ -41,14 +47,21 @@ const CinemaPage = ({
   data,
   city,
   cinema,
+  cinemaName,
+  cityName,
 }: {
   data: Screening[]
   city: string
   cinema: string
+  cinemaName: string
+  cityName: string
 }) => {
   return (
     <>
-      <SEO title="Home" />
+      <SEO
+        title={`${cinemaName}, ${cityName}`}
+        canonical={`https://expatcinema.com/city/${city}/cinema/${cinema}`}
+      />
       <App screenings={data} currentCity={city} currentCinema={cinema} />
     </>
   )

--- a/web/pages/city/[city]/index.tsx
+++ b/web/pages/city/[city]/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { App } from '../../../components/App'
 import { SEO } from '../../../components/Seo'
 import cities from '../../../data/city.json'
+import { getCity } from '../../../utils/getCity'
 import { Screening, getScreenings } from '../../../utils/getScreenings'
 
 export const getStaticPaths = () => {
@@ -23,19 +24,32 @@ export const getStaticProps = async ({
   const screenings = (await getScreenings()).filter(
     (screening) => screening.cinema.city.name.toLowerCase() === city,
   )
+  const cityName = getCity(city)?.name ?? city
 
   return {
     props: {
       data: screenings,
       city,
+      cityName,
     },
   }
 }
 
-const CityPage = ({ data, city }: { data: Screening[]; city: string }) => {
+const CityPage = ({
+  data,
+  city,
+  cityName,
+}: {
+  data: Screening[]
+  city: string
+  cityName: string
+}) => {
   return (
     <>
-      <SEO title="Home" />
+      <SEO
+        title={cityName}
+        canonical={`https://expatcinema.com/city/${city}`}
+      />
       <App screenings={data} currentCity={city} />
     </>
   )

--- a/web/utils/getCinema.ts
+++ b/web/utils/getCinema.ts
@@ -1,0 +1,3 @@
+import cinemas from '../data/cinema.json'
+
+export const getCinema = (slug: string) => cinemas.find((c) => c.slug === slug)

--- a/web/utils/getCity.ts
+++ b/web/utils/getCity.ts
@@ -1,0 +1,4 @@
+import cities from '../data/city.json'
+
+export const getCity = (slug: string) =>
+  cities.find((c) => c.name.toLowerCase() === slug)


### PR DESCRIPTION
## Summary

- `SEO` component: separator changed from `|` to `–`, `canonical` prop added (defaults to `https://expatcinema.com`)
- City pages (`/city/rotterdam`): title is now "Rotterdam – Expat Cinema" with a page-specific canonical URL
- Cinema pages (`/city/rotterdam/cinema/kino`): title is now "Kino, Rotterdam – Expat Cinema" with a page-specific canonical URL
- Added `utils/getCity.ts` and `utils/getCinema.ts` for looking up display names by slug

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)