### PR TITLE
Add better 404 page

### DIFF
--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,3 +1,26 @@
+import Link from 'next/link'
+
+import { Layout } from '../components/Layout'
+import { NavigationBar } from '../components/NavigationBar'
+import { PageTitle } from '../components/PageTitle'
+import { palette } from '../utils/theme'
+
+const textLinkStyle = { color: 'var(--secondary-color)' }
+
 export default function NotFound() {
-  return <div>Not found</div>
+  return (
+    <>
+      <Layout backgroundColor={palette.purple600}>
+        <NavigationBar showSearch={false} />
+      </Layout>
+      <Layout>
+        <PageTitle>Page not found</PageTitle>
+        <p style={{ fontSize: '18px', lineHeight: '1.4' }}>
+          <Link href="/" style={textLinkStyle}>
+            Go to homepage
+          </Link>
+        </p>
+      </Layout>
+    </>
+  )
 }


### PR DESCRIPTION
## Summary
- Replaces the bare `<div>Not found</div>` with a proper 404 page
- Shows the dark purple navigation header (search hidden, as it's not useful on a 404)
- Displays a "Page not found" title and a "Go to homepage" link, styled consistently with the About page

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)