### PR TITLE
Fix 404 page prerender error

### DIFF
--- a/web/app/not-found.tsx
+++ b/web/app/not-found.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Suspense } from 'react'
 
 import { Layout } from '../components/Layout'
 import { NavigationBar } from '../components/NavigationBar'
@@ -9,7 +10,7 @@ const textLinkStyle = { color: 'var(--secondary-color)' }
 
 export default function NotFound() {
   return (
-    <>
+    <Suspense>
       <Layout backgroundColor={palette.purple600}>
         <NavigationBar showSearch={false} />
       </Layout>
@@ -21,6 +22,6 @@ export default function NotFound() {
           </Link>
         </p>
       </Layout>
-    </>
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- Wraps the 404 page content in `<Suspense>`, matching the pattern used by all other pages
- Fixes the build error: `NavigationBar` uses `useSearchParams()` which requires a `<Suspense>` boundary during static export prerendering

Fixes the build failure introduced by #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)