### PR TITLE
Add web-build CI workflow

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -1,0 +1,36 @@
+name: Web Build
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - '.github/workflows/web-build.yml'
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+      - name: Restore cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build with Next.js
+        run: pnpm next build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/web-build.yml` — a lightweight CI workflow that runs `next build` on pull requests touching `web/`
- Does **not** deploy; purely for catching build errors before merging (like the one in #189)
- Triggers on PRs only (not pushes to main or schedule)
- Stripped down from `web.yml`: no Pages setup, no sitemap, no artifact upload, no deploy job, no package manager detection (hardcoded pnpm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)