### PR TITLE
Add empty state message when no screenings match

### DIFF
--- a/web/components/App.tsx
+++ b/web/components/App.tsx
@@ -12,7 +12,7 @@ export const App = ({
   screenings,
   showCity = true,
   currentCity,
-  currentCinema: _currentCinema,
+  currentCinema,
 }: {
   screenings: Screening[]
   showCity?: boolean
@@ -33,7 +33,12 @@ export const App = ({
         </Layout>
       )}
       <Layout>
-        <Calendar screenings={screenings} showCity={showCity} />
+        <Calendar
+          screenings={screenings}
+          showCity={showCity}
+          currentCity={currentCity}
+          currentCinema={currentCinema}
+        />
       </Layout>
     </>
   )

--- a/web/components/Calendar/index.tsx
+++ b/web/components/Calendar/index.tsx
@@ -4,9 +4,12 @@ import { DateTime } from 'luxon'
 import dynamic from 'next/dynamic'
 import React from 'react'
 
-import { css } from 'styled-system/css'
+import { css, cx } from 'styled-system/css'
 
 import { isEnabled } from '../../utils/featureFlags'
+import { headerFont } from '../../utils/theme'
+import { getCinema } from '../../utils/getCinema'
+import { getCity } from '../../utils/getCity'
 import { Screening } from '../../utils/getScreenings'
 import {
   ScreeningWithLuxonDate,
@@ -32,6 +35,12 @@ const containerStyle = css({
   marginBottom: '24px',
 })
 
+const emptyStateStyle = css({
+  fontSize: '16px',
+  fontWeight: '700',
+  margin: '12px 0',
+})
+
 const screeningMatchesSearch = (
   screening: ScreeningWithLuxonDate,
   searchComponents: string[],
@@ -54,11 +63,15 @@ const screeningMatchesSearch = (
 export const Calendar = ({
   screenings,
   showCity,
+  currentCity,
+  currentCinema,
 }: {
   screenings: Screening[]
   showCity: boolean
+  currentCity?: string
+  currentCinema?: string
 }) => {
-  const { searchComponents } = useSearch()
+  const { search, searchComponents } = useSearch()
 
   const screeningsByDate = Object.entries(
     groupAndSortScreenings(screenings),
@@ -82,9 +95,33 @@ export const Calendar = ({
     ]
   })
 
+  const locationLabel = (() => {
+    if (currentCinema) {
+      const cinemaData = getCinema(currentCinema)
+      if (cinemaData) return `in ${cinemaData.name}, ${cinemaData.city}`
+    }
+    if (currentCity) {
+      const cityData = getCity(currentCity)
+      if (cityData) return `in ${cityData.name}`
+    }
+    return null
+  })()
+
+  const emptyStateMessage = [
+    'No screenings found',
+    locationLabel,
+    search ? `for ${search}` : null,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
     <div className={containerStyle}>
-      <CalendarComponent rows={rows} showCity={showCity} />
+      {rows.length === 0 ? (
+        <h3 className={cx(emptyStateStyle, headerFont.className)}>{emptyStateMessage}</h3>
+      ) : (
+        <CalendarComponent rows={rows} showCity={showCity} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Shows a context-aware empty state message when filtering results in zero screenings
- Message adapts based on context: city, cinema, and/or search term
- Examples: *No screenings found in Tilburg*, *No screenings found in Kino, Rotterdam for xyznotfound*
- Styled to match the existing date headers (same serif font and weight)

Closes #123

## Test plan

- [ ] Homepage with a search term that matches nothing → *No screenings found for {term}*
- [ ] City page with no screenings (e.g. `/city/tilburg`) → *No screenings found in {City}*
- [ ] Cinema page with a search that matches nothing → *No screenings found in {Cinema}, {City} for {term}*
- [ ] Verify normal screening lists still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)