### PR TITLE
Fix city display name in empty state message

### DIFF
--- a/web/components/Calendar/index.tsx
+++ b/web/components/Calendar/index.tsx
@@ -98,7 +98,10 @@ export const Calendar = ({
   const locationLabel = (() => {
     if (currentCinema) {
       const cinemaData = getCinema(currentCinema)
-      if (cinemaData) return `in ${cinemaData.name}, ${cinemaData.city}`
+      if (cinemaData) {
+        const cityName = getCity(currentCity ?? '')?.name ?? cinemaData.city
+        return `in ${cinemaData.name}, ${cityName}`
+      }
     }
     if (currentCity) {
       const cityData = getCity(currentCity)


### PR DESCRIPTION
## Summary

- The cinema branch of `locationLabel` was using `cinemaData.city` which can be a raw slug (e.g. `den-haag`) rather than the proper display name
- Fix: resolve the city name through `getCity(currentCity)` first (which returns the proper cased name from city.json), with `cinemaData.city` as a fallback

Fixes #123 (follow-up to #192)

🤖 Generated with [Claude Code](https://claude.com/claude-code)