### PR TITLE
Scroll active city into view in CityFilter

### DIFF
--- a/web/components/ActiveLink.tsx
+++ b/web/components/ActiveLink.tsx
@@ -19,44 +19,54 @@ const baseLinkStyle = css({
   borderRadius: '4px',
 })
 
-export const ActiveLink = ({
-  children,
-  href,
-  activeColor = palette.purple500,
-  activeBackgroundColor = 'var(--primary-color)',
-  inactiveColor = 'var(--text-inverse-color)',
-  matchPrefix = false,
-}: {
-  children: React.ReactNode
-  href: string
-  activeColor?: string
-  activeBackgroundColor?: string
-  inactiveColor?: string
-  matchPrefix?: boolean
-}) => {
-  const pathname = usePathname()
-  const [isCurrent, setIsCurrent] = useState(false)
+export const ActiveLink = React.forwardRef<
+  HTMLAnchorElement,
+  {
+    children: React.ReactNode
+    href: string
+    activeColor?: string
+    activeBackgroundColor?: string
+    inactiveColor?: string
+    matchPrefix?: boolean
+  }
+>(
+  (
+    {
+      children,
+      href,
+      activeColor = palette.purple500,
+      activeBackgroundColor = 'var(--primary-color)',
+      inactiveColor = 'var(--text-inverse-color)',
+      matchPrefix = false,
+    },
+    ref,
+  ) => {
+    const pathname = usePathname()
+    const [isCurrent, setIsCurrent] = useState(false)
 
-  useEffect(() => {
-    const linkPathname = new URL(href, location.href).pathname
-    setIsCurrent(
-      linkPathname === pathname ||
-        (matchPrefix &&
-          linkPathname !== '/' &&
-          pathname.startsWith(linkPathname + '/')),
+    useEffect(() => {
+      const linkPathname = new URL(href, location.href).pathname
+      setIsCurrent(
+        linkPathname === pathname ||
+          (matchPrefix &&
+            linkPathname !== '/' &&
+            pathname.startsWith(linkPathname + '/')),
+      )
+    }, [pathname, href, matchPrefix])
+
+    return (
+      <Link
+        ref={ref}
+        href={href}
+        className={baseLinkStyle}
+        style={{
+          color: isCurrent ? activeColor : inactiveColor,
+          backgroundColor: isCurrent ? activeBackgroundColor : 'transparent',
+        }}
+      >
+        {children}
+      </Link>
     )
-  }, [pathname, href, matchPrefix])
-
-  return (
-    <Link
-      href={href}
-      className={baseLinkStyle}
-      style={{
-        color: isCurrent ? activeColor : inactiveColor,
-        backgroundColor: isCurrent ? activeBackgroundColor : 'transparent',
-      }}
-    >
-      {children}
-    </Link>
-  )
-}
+  },
+)
+ActiveLink.displayName = 'ActiveLink'

--- a/web/components/CityFilter.tsx
+++ b/web/components/CityFilter.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef } from 'react'
 
-import { usePathname } from 'next/navigation'
+import { useParams } from 'next/navigation'
 
 import { css, cx } from 'styled-system/css'
 
@@ -28,42 +28,42 @@ Container.displayName = 'Container'
 
 export const CityFilter = () => {
   const { searchQuery } = useSearch()
-  const pathname = usePathname()
-  const containerRef = useRef<HTMLDivElement>(null)
+  const { city } = useParams<{ city?: string }>()
+  const linkRefs = useRef<Map<string, HTMLAnchorElement>>(new Map())
 
   const links = [
-    { text: 'All', href: `/${searchQuery}` },
+    { text: 'All', slug: null, href: `/${searchQuery}` },
     ...cities.map(({ name, slug }) => ({
       text: name,
+      slug,
       href: `/city/${slug}${searchQuery}`,
     })),
   ]
 
   useEffect(() => {
-    if (!containerRef.current) return
-    for (const a of containerRef.current.querySelectorAll<HTMLAnchorElement>('a')) {
-      const linkPathname = new URL(a.href).pathname
-      if (
-        linkPathname === pathname ||
-        (linkPathname !== '/' && pathname.startsWith(linkPathname + '/'))
-      ) {
-        a.scrollIntoView({ inline: 'nearest', block: 'nearest' })
-        break
-      }
-    }
-  }, [pathname])
+    if (!city) return
+    linkRefs.current.get(city)?.scrollIntoView({ inline: 'nearest', block: 'nearest' })
+  }, [city])
 
   return (
     <Container
-      ref={containerRef}
       className={css({
         display: 'flex',
         backgroundColor: 'var(--secondary-color)',
         gap: '12px',
       })}
     >
-      {links.map(({ text, href }) => (
-        <ActiveLink href={href} key={text} matchPrefix>
+      {links.map(({ text, slug, href }) => (
+        <ActiveLink
+          ref={(el) => {
+            if (slug === null) return
+            if (el) linkRefs.current.set(slug, el)
+            else linkRefs.current.delete(slug)
+          }}
+          href={href}
+          key={text}
+          matchPrefix
+        >
           {text}
         </ActiveLink>
       ))}


### PR DESCRIPTION
When visiting /city/tilburg, the city filter now scrolls to show
the active city chip, fixing the issue where Tilburg was filtered
but not visible in the filter bar.

https://claude.ai/code/session_01P6EFTbBrQqyhTe77pJUbzg