### PR TITLE
Scroll active cinema into view in CinemaFilter

### DIFF
--- a/web/components/CinemaFilter.tsx
+++ b/web/components/CinemaFilter.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 
+import { useParams } from 'next/navigation'
 import { css } from 'styled-system/css'
 
 import cinemas from '../data/cinema.json'
@@ -17,26 +18,40 @@ const containerOverrideStyle = css({
 
 export const CinemaFilter = ({ currentCity }: { currentCity: string }) => {
   const { searchQuery } = useSearch()
+  const { cinema } = useParams<{ cinema?: string }>()
+  const linkRefs = useRef<Map<string, HTMLAnchorElement>>(new Map())
 
-  const cinemasInCity = cinemas.filter(
-    (cinema) => cinema.city === currentCity,
-  )
+  const cinemasInCity = cinemas.filter((c) => c.city === currentCity)
 
   const links = [
-    { text: 'All', href: `/city/${currentCity}${searchQuery}` },
-    ...cinemasInCity.map((cinema) => ({
-      text: cinema.name,
-      href: `/city/${currentCity}/cinema/${cinema.slug}${searchQuery}`,
+    { text: 'All', slug: null, href: `/city/${currentCity}${searchQuery}` },
+    ...cinemasInCity.map((c) => ({
+      text: c.name,
+      slug: c.slug,
+      href: `/city/${currentCity}/cinema/${c.slug}${searchQuery}`,
     })),
   ]
+
+  useEffect(() => {
+    if (cinema) {
+      linkRefs.current
+        .get(cinema)
+        ?.scrollIntoView({ inline: 'nearest', block: 'nearest' })
+    }
+  }, [cinema])
 
   return (
     <Container
       className={containerOverrideStyle}
       style={{ backgroundColor: palette.purple300 }}
     >
-      {links.map(({ text, href }) => (
+      {links.map(({ text, slug, href }) => (
         <ActiveLink
+          ref={(el) => {
+            if (slug === null) return
+            if (el) linkRefs.current.set(slug, el)
+            else linkRefs.current.delete(slug)
+          }}
           href={href}
           key={text}
           activeColor={palette.purple100}


### PR DESCRIPTION
## Summary
- Adds scroll-into-view behavior to CinemaFilter, matching the existing CityFilter implementation
- When navigating to a cinema-specific page, the active cinema link in the horizontal filter bar automatically scrolls into view

## Test plan
- [ ] Navigate to a city with many cinemas (e.g. Amsterdam) and select a cinema toward the end of the list
- [ ] Verify the selected cinema link scrolls into the visible area of the filter bar
- [ ] Verify the "All" link and early cinemas still work without unexpected scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)