### PR TITLE
Convert RelativeDate and Time class components to functional components

### DIFF
--- a/web/components/RelativeDate.tsx
+++ b/web/components/RelativeDate.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { DateTime } from 'luxon'
-import React from 'react'
 
 import { css, cx } from 'styled-system/css'
 
@@ -14,22 +13,18 @@ const dateStyle = css({
   margin: '12px 0',
 })
 
-export class RelativeDate extends React.PureComponent<{ children: string }> {
-  render() {
-    const date = DateTime.fromISO(this.props.children)
-    const today = getToday()
+export const RelativeDate = ({ children }: { children: string }) => {
+  const date = DateTime.fromISO(children)
+  const today = getToday()
 
-    const diff = date.diff(today, 'days').days
+  const diff = date.diff(today, 'days').days
 
-    let relativeDate = date.toFormat('EEEE d MMMM')
-    if (diff === 0) {
-      relativeDate = 'Today'
-    } else if (diff === 1) {
-      relativeDate = 'Tomorrow'
-    }
-
-    return (
-      <h3 className={cx(dateStyle, headerFont.className)}>{relativeDate}</h3>
-    )
+  let relativeDate = date.toFormat('EEEE d MMMM')
+  if (diff === 0) {
+    relativeDate = 'Today'
+  } else if (diff === 1) {
+    relativeDate = 'Tomorrow'
   }
+
+  return <h3 className={cx(dateStyle, headerFont.className)}>{relativeDate}</h3>
 }

--- a/web/components/Time.tsx
+++ b/web/components/Time.tsx
@@ -1,14 +1,11 @@
 import { DateTime } from 'luxon'
-import React from 'react'
 
-export class Time extends React.PureComponent<{ children: DateTime }> {
-  render() {
-    return (
-      <div style={{ fontSize: 18 }}>
-        {this.props.children
-          .setZone('Europe/Amsterdam')
-          .toLocaleString(DateTime.TIME_24_SIMPLE, { locale: 'en-GB' })}
-      </div>
-    )
-  }
+export const Time = ({ children }: { children: DateTime }) => {
+  return (
+    <div style={{ fontSize: 18 }}>
+      {children
+        .setZone('Europe/Amsterdam')
+        .toLocaleString(DateTime.TIME_24_SIMPLE, { locale: 'en-GB' })}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary

- Converts `RelativeDate` from `React.PureComponent` to a plain arrow function component
- Converts `Time` from `React.PureComponent` to a plain arrow function component
- Removes the now-unnecessary `import React from 'react'` in both files (project uses `react-jsx` transform)

All existing logic is preserved exactly — only the component form changes.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)