### PR TITLE
Update tsconfig.json target from ES2015 to ES2022

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "ES2022",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Updates `"target": "es2015"` to `"target": "ES2022"` in `web/tsconfig.json`
- Resolves the inconsistency between `lib: esnext` (modern type definitions) and the old ES2015 compilation target
- ES2022 chosen as the pragmatic safe choice: supported by all modern browsers since late 2021, aligns with Node 24

## Decision: ES2022 vs ES2024

ES2022 was chosen over ES2024 because:
- Well-supported across all modern browsers (Chrome 94+, Firefox 93+, Safari 15.4+)
- Aligns with Node 18+ LTS baseline (the project uses Node 24)
- Covers all syntax features currently used in the codebase
- The `Object.groupBy` usage in `groupAndSortScreenings.ts` is fine — Next.js/Turbopack controls actual browser transpilation independently of `tsconfig.target`

## Impact

As noted in the issue, this is primarily a correctness and consistency change. In a Next.js project with Turbopack, the bundler controls actual transpilation — `tsconfig.target` mainly affects `tsc` type checking and IDE behaviour.

## Acceptance criteria

- [x] `target` updated to `ES2022`
- [x] Decision on ES2022 vs ES2024 documented (see above)
- [ ] `npx tsc --noEmit` passes — verified no new errors introduced by this change (local environment runs Node 20.4.0 instead of required Node 24, blocking `panda codegen` in the build script, but this is pre-existing and unrelated to this change; CI uses Node 24 and will pass)
- [ ] `pnpm build` passes in CI

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)