### PR TITLE
Fix panda.config.ts include paths: pages/ → app/

### DIFF
--- a/web/panda.config.ts
+++ b/web/panda.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   preflight: false,
 
   include: [
-    './pages/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}',
     './utils/**/*.{ts,tsx}',
   ],


### PR DESCRIPTION
## Summary

- Replaces `./pages/**/*.{ts,tsx}` with `./app/**/*.{ts,tsx}` in `panda.config.ts`

The project uses Next.js App Router with an `app/` directory — there is no `pages/` directory. Panda CSS was scanning a non-existent path and missing all files under `app/` during CSS generation.

Closes #198

🤖 Generated with [Claude Code](https://claude.ai/claude-code)