### PR TITLE
Fix About page showing city slug instead of city name

### DIFF
--- a/web/components/About.tsx
+++ b/web/components/About.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { css } from 'styled-system/css'
 
 import cinemas from '../data/cinema.json'
+import { getCity } from '../utils/getCity'
 import { palette } from '../utils/theme'
 import { Layout } from './Layout'
 import { NavigationBar } from './NavigationBar'
@@ -26,7 +27,7 @@ const textLinkStyle = css({
   color: 'var(--secondary-color)',
 })
 
-const cities = [...new Set(cinemas.map((cinema) => cinema.city))].sort()
+const citySlugs = [...new Set(cinemas.map((cinema) => cinema.city))].sort()
 
 export const About = () => {
   return (
@@ -55,8 +56,8 @@ export const About = () => {
             </Link>
           </p>
           <br />
-          {cities.map((city) => {
-            const href = `/city/${city.toLowerCase()}`
+          {citySlugs.map((city) => {
+            const href = `/city/${city}`
             const cinemasInCity = cinemas
               .filter((cinema) => cinema.city === city)
               .sort((a, b) => a.name.localeCompare(b.name))
@@ -64,7 +65,7 @@ export const About = () => {
             return (
               <>
                 <Link href={href} className={cityLinkStyle}>
-                  {city}
+                  {getCity(city)?.name ?? city}
                 </Link>
                 :{' '}
                 {cinemasInCity.map((cinema, i, arr) => {


### PR DESCRIPTION
## Summary

- Fixes the About page rendering city slugs (e.g. `den-haag`) as link text instead of display names (e.g. `Den Haag`)
- Imports `getCity` from `utils/getCity` and calls `getCity(city)?.name ?? city` to resolve each slug to its display name
- Renames `cities` to `citySlugs` for clarity
- Removes the redundant `.toLowerCase()` on the href since `cinema.city` is already a slug

Closes #211

## Test plan

- [ ] Verify the About page shows "Den Haag" (and other proper names) instead of "den-haag" as city link text
- [ ] Confirm city links still navigate to the correct `/city/<slug>` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)