### PR TITLE
Fix CityFilter and CinemaFilter scroll jump by using shared layouts

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,8 @@
       "name": "web (Next.js)",
       "runtimeExecutable": "/bin/bash",
       "runtimeArgs": ["-c", "PATH=/Users/ckuijjer/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter web-nextjs dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
-import { App } from '../../../../../components/App'
-import cinemas from '../../../../../data/cinema.json'
-import { getCinema } from '../../../../../utils/getCinema'
-import { getScreenings } from '../../../../../utils/getScreenings'
+import { App } from '../../../../../../components/App'
+import cinemas from '../../../../../../data/cinema.json'
+import { getCinema } from '../../../../../../utils/getCinema'
+import { getScreenings } from '../../../../../../utils/getScreenings'
 
 export const generateStaticParams = () =>
   cinemas.map((cinema) => ({

--- a/web/app/(screenings)/city/[city]/layout.tsx
+++ b/web/app/(screenings)/city/[city]/layout.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense } from 'react'
+
+import { CinemaFilter } from '../../../../components/CinemaFilter'
+import { Layout } from '../../../../components/Layout'
+import { palette } from '../../../../utils/theme'
+
+export default function CityLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <Layout backgroundColor={palette.purple300}>
+        <Suspense>
+          <CinemaFilter />
+        </Suspense>
+      </Layout>
+      {children}
+    </>
+  )
+}

--- a/web/app/(screenings)/city/[city]/page.tsx
+++ b/web/app/(screenings)/city/[city]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
-import { App } from '../../../components/App'
-import cities from '../../../data/city.json'
-import { getCity } from '../../../utils/getCity'
-import { getScreenings } from '../../../utils/getScreenings'
+import { App } from '../../../../components/App'
+import cities from '../../../../data/city.json'
+import { getCity } from '../../../../utils/getCity'
+import { getScreenings } from '../../../../utils/getScreenings'
 
 export const generateStaticParams = () =>
   cities.map((city) => ({ city: city.slug }))

--- a/web/app/(screenings)/layout.tsx
+++ b/web/app/(screenings)/layout.tsx
@@ -1,0 +1,28 @@
+import React, { Suspense } from 'react'
+
+import { CityFilter } from '../../components/CityFilter'
+import { Layout } from '../../components/Layout'
+import { NavigationBar } from '../../components/NavigationBar'
+import { palette } from '../../utils/theme'
+
+export default function ScreeningsLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      <Layout backgroundColor={palette.purple600}>
+        <Suspense>
+          <NavigationBar />
+        </Suspense>
+      </Layout>
+      <Layout backgroundColor={palette.purple400}>
+        <Suspense>
+          <CityFilter />
+        </Suspense>
+      </Layout>
+      {children}
+    </>
+  )
+}

--- a/web/app/(screenings)/page.tsx
+++ b/web/app/(screenings)/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
-import { App } from '../components/App'
-import { getScreenings } from '../utils/getScreenings'
+import { App } from '../../components/App'
+import { getScreenings } from '../../utils/getScreenings'
 
 export const metadata: Metadata = {
   title: 'Expat Cinema',

--- a/web/components/App.tsx
+++ b/web/components/App.tsx
@@ -1,12 +1,8 @@
 import React from 'react'
 
 import { Screening } from '../utils/getScreenings'
-import { palette } from '../utils/theme'
 import { Calendar } from './Calendar'
-import { CinemaFilter } from './CinemaFilter'
-import { CityFilter } from './CityFilter'
 import { Layout } from './Layout'
-import { NavigationBar } from './NavigationBar'
 
 export const App = ({
   screenings,
@@ -20,26 +16,13 @@ export const App = ({
   currentCinema?: string
 }) => {
   return (
-    <>
-      <Layout backgroundColor={palette.purple600}>
-        <NavigationBar />
-      </Layout>
-      <Layout backgroundColor={palette.purple400}>
-        <CityFilter />
-      </Layout>
-      {currentCity !== undefined && (
-        <Layout backgroundColor={palette.purple300}>
-          <CinemaFilter currentCity={currentCity} />
-        </Layout>
-      )}
-      <Layout>
-        <Calendar
-          screenings={screenings}
-          showCity={showCity}
-          currentCity={currentCity}
-          currentCinema={currentCinema}
-        />
-      </Layout>
-    </>
+    <Layout>
+      <Calendar
+        screenings={screenings}
+        showCity={showCity}
+        currentCity={currentCity}
+        currentCinema={currentCinema}
+      />
+    </Layout>
   )
 }

--- a/web/components/CinemaFilter.tsx
+++ b/web/components/CinemaFilter.tsx
@@ -16,32 +16,42 @@ const containerOverrideStyle = css({
   gap: '12px',
 })
 
-export const CinemaFilter = ({ currentCity }: { currentCity: string }) => {
+export const CinemaFilter = () => {
   const { searchQuery } = useSearch()
-  const { cinema } = useParams<{ cinema?: string }>()
+  const { city, cinema } = useParams<{ city: string; cinema?: string }>()
   const linkRefs = useRef<Map<string, HTMLAnchorElement>>(new Map())
 
-  const cinemasInCity = cinemas.filter((c) => c.city === currentCity)
+  const cinemasInCity = cinemas.filter((c) => c.city === city)
 
   const links = [
-    { text: 'All', slug: null, href: `/city/${currentCity}${searchQuery}` },
+    { text: 'All', slug: null, href: `/city/${city}${searchQuery}` },
     ...cinemasInCity.map((c) => ({
       text: c.name,
       slug: c.slug,
-      href: `/city/${currentCity}/cinema/${c.slug}${searchQuery}`,
+      href: `/city/${city}/cinema/${c.slug}${searchQuery}`,
     })),
   ]
 
+  const containerRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
-    if (cinema) {
-      linkRefs.current
-        .get(cinema)
-        ?.scrollIntoView({ inline: 'nearest', block: 'nearest' })
+    const link = cinema ? linkRefs.current.get(cinema) : null
+    const container = containerRef.current
+    if (!link || !container) return
+
+    const linkRect = link.getBoundingClientRect()
+    const containerRect = container.getBoundingClientRect()
+
+    if (linkRect.left < containerRect.left) {
+      container.scrollLeft += linkRect.left - containerRect.left
+    } else if (linkRect.right > containerRect.right) {
+      container.scrollLeft += linkRect.right - containerRect.right
     }
   }, [cinema])
 
   return (
     <Container
+      ref={containerRef}
       className={containerOverrideStyle}
       style={{ backgroundColor: palette.purple300 }}
     >

--- a/web/components/CityFilter.tsx
+++ b/web/components/CityFilter.tsx
@@ -40,14 +40,26 @@ export const CityFilter = () => {
     })),
   ]
 
+  const containerRef = useRef<HTMLDivElement>(null)
+
   useEffect(() => {
-      if (city) {
-        linkRefs.current.get(city)?.scrollIntoView({ inline: 'nearest', block: 'nearest' })
-      }
+    const link = city ? linkRefs.current.get(city) : null
+    const container = containerRef.current
+    if (!link || !container) return
+
+    const linkRect = link.getBoundingClientRect()
+    const containerRect = container.getBoundingClientRect()
+
+    if (linkRect.left < containerRect.left) {
+      container.scrollLeft += linkRect.left - containerRect.left
+    } else if (linkRect.right > containerRect.right) {
+      container.scrollLeft += linkRect.right - containerRect.right
+    }
   }, [city])
 
   return (
     <Container
+      ref={containerRef}
       className={css({
         display: 'flex',
         backgroundColor: 'var(--secondary-color)',


### PR DESCRIPTION
Move NavigationBar + CityFilter into a (screenings) route group layout, and CinemaFilter into a city-level layout, so both components persist across client-side navigations and never remount. Replace scrollIntoView() (which scrolls all ancestor containers including the page body) with manual scrollLeft adjustment using getBoundingClientRect, so only the filter bar scrolls horizontally and only when the active link is actually clipped.