### PR TITLE
Fix De Uitkijk scraper title extraction

### DIFF
--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -49,7 +49,8 @@ const extractDate = (time: string) =>
 const cleanTitle = (title: string) =>
   titleCase(
     title
-      .replace(/ \(.*?\)$/g, '')
+      .replace(/\s*\|.*$/, '')
+      .replace(/ \(.*?\)/g, '')
       .replace(/^110 Jaar De Uitkijk:/i, '')
       .replace(/^Klassieker:/i, '')
       .trim(),


### PR DESCRIPTION
## Changes

- Updated `cleanTitle` function in the De Uitkijk scraper to improve title extraction
- Added removal of pipe-separated suffixes (`|.*$`) before processing parenthetical content
- Modified parenthetical content removal to handle spaces before the opening parenthesis

These changes ensure event titles are cleaned more accurately by handling additional title formats.