### PR TITLE
Support year-aware TMDB movie searches

### DIFF
--- a/cloud/metadata/index.ts
+++ b/cloud/metadata/index.ts
@@ -2,11 +2,20 @@ import searchMetadata from './searchMetadata'
 import { normalizeMovieTitleForLookup } from './titleResolver'
 import { Metadata } from './types'
 
-const getMetadata = async (title: string): Promise<Metadata> => {
-  const metadata = await searchMetadata(title)
+type MetadataLookup = {
+  title: string
+  year?: number
+}
+
+const getMetadata = async ({
+  title,
+  year,
+}: MetadataLookup): Promise<Metadata> => {
+  const metadata = await searchMetadata(title, year)
 
   return {
     query: normalizeMovieTitleForLookup(title),
+    year,
     createdAt: new Date().toISOString(),
     ...metadata,
   }

--- a/cloud/metadata/manualTitleOverrides.ts
+++ b/cloud/metadata/manualTitleOverrides.ts
@@ -2,6 +2,7 @@ import { normalizeMovieTitleForLookup } from './titleResolver'
 
 type ManualTitleOverrideInput = {
   title: string
+  year?: number
   tmdbId?: number
   imdbId?: string
   note?: string
@@ -20,7 +21,11 @@ export const manualTitleOverrides: ManualTitleOverride[] = rawOverrides.map(
   }),
 )
 
-export const getManualTitleOverride = (title: string) => {
+export const getManualTitleOverride = (title: string, year?: number) => {
   const query = normalizeMovieTitleForLookup(title)
-  return manualTitleOverrides.find((override) => override.query === query)
+  return (
+    manualTitleOverrides.find(
+      (override) => override.query === query && override.year === year,
+    ) ?? manualTitleOverrides.find((override) => override.query === query)
+  )
 }

--- a/cloud/metadata/searchMetadata.ts
+++ b/cloud/metadata/searchMetadata.ts
@@ -26,11 +26,12 @@ const getTmdb = () => {
   return getTmdbClient(apiKey)
 }
 
-const searchTmdb = async (query: string) => {
+const searchTmdb = async (query: string, year?: number) => {
   const tmdb = getTmdb()
   const { results } = (await tmdb.get('search/movie', {
     searchParams: {
       query,
+      ...(year ? { primary_release_year: year } : {}),
     },
   })) as unknown as TmdbSearchResponse
 
@@ -90,6 +91,7 @@ const buildResolvedMetadata = (
 
 const searchMetadata = async (
   title: string,
+  year?: number,
 ): Promise<Omit<Metadata, 'query' | 'createdAt'>> => {
   const normalizedTitle = normalizeMovieTitleForLookup(title)
   const manualOverride = getManualTitleOverride(title)
@@ -125,7 +127,7 @@ const searchMetadata = async (
   const uniqueCandidates = new Map<number, TmdbMovieResult>()
 
   for (const query of searchQueries) {
-    const results = await searchTmdb(query)
+    const results = await searchTmdb(query, year)
     results.slice(0, 5).forEach((result) => {
       uniqueCandidates.set(result.id, result)
     })
@@ -134,7 +136,7 @@ const searchMetadata = async (
   const scoredCandidates = Array.from(uniqueCandidates.values())
     .map((candidate) => ({
       candidate,
-      confidence: scoreCandidate(title, candidate),
+      confidence: scoreCandidate(title, candidate, year),
     }))
     .sort((left, right) => right.confidence - left.confidence)
 
@@ -143,6 +145,7 @@ const searchMetadata = async (
 
   logger.info('searchMetadata scored candidates', {
     normalizedTitle,
+    year,
     searchQueries,
     scoredCandidates: scoredCandidates.slice(0, 5).map((entry) => ({
       tmdbId: entry.candidate.id,

--- a/cloud/metadata/searchMetadata.ts
+++ b/cloud/metadata/searchMetadata.ts
@@ -94,7 +94,7 @@ const searchMetadata = async (
   year?: number,
 ): Promise<Omit<Metadata, 'query' | 'createdAt'>> => {
   const normalizedTitle = normalizeMovieTitleForLookup(title)
-  const manualOverride = getManualTitleOverride(title)
+  const manualOverride = getManualTitleOverride(title, year)
 
   if (manualOverride?.tmdbId) {
     const tmdbMovie = await getTmdbMovie(manualOverride.tmdbId)

--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -91,6 +91,9 @@ const similarity = (left: string, right: string) => {
 
 export const getMovieId = (tmdbId: number) => `tmdb:${tmdbId}`
 
+export const getMetadataLookupKey = (title: string, year?: number) =>
+  `${normalizeMovieTitleForLookup(title)}::${year ?? ''}`
+
 type ScoreCandidateInput = {
   title?: string
   originalTitle?: string
@@ -101,12 +104,13 @@ type ScoreCandidateInput = {
 export const scoreCandidate = (
   rawTitle: string,
   candidate: ScoreCandidateInput,
+  yearHintOverride?: number,
 ) => {
   const normalizedRaw = normalizeMovieTitleForLookup(rawTitle)
   const normalizedStripped = normalizeMovieTitleForLookup(
     stripTitleNoise(rawTitle),
   )
-  const yearHint = extractYearHint(rawTitle)
+  const yearHint = yearHintOverride ?? extractYearHint(rawTitle)
 
   const candidateTitles = [
     candidate.title,

--- a/cloud/metadata/types.ts
+++ b/cloud/metadata/types.ts
@@ -42,6 +42,7 @@ export type MetadataMatch = {
 
 export type Metadata = {
   query: string
+  year?: number
   createdAt: string
   movieId?: string
   title?: string

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -44,7 +44,10 @@ import springhaver from './springhaver'
 import studiok from './studiok'
 import themovies from './themovies'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
-import { normalizeMovieTitleForLookup } from '../metadata/titleResolver'
+import {
+  getMetadataLookupKey,
+  normalizeMovieTitleForLookup,
+} from '../metadata/titleResolver'
 
 const SCRAPERS = {
   bioscopenleiden,
@@ -207,19 +210,33 @@ export const scrapers = async () => {
       Object.values(results).flat(),
     )
 
-    const titleQueriesToRawTitles = new Map<string, Set<string>>()
-    allRawScreenings.forEach(({ title }) => {
+    const metadataLookups = new Map<
+      string,
+      { query: string; year?: number; rawTitles: Set<string> }
+    >()
+    allRawScreenings.forEach(({ title, year }) => {
       const query = normalizeMovieTitleForLookup(title)
-      const rawTitles = titleQueriesToRawTitles.get(query) ?? new Set<string>()
-      rawTitles.add(title)
-      titleQueriesToRawTitles.set(query, rawTitles)
+      const lookupKey = getMetadataLookupKey(title, year)
+      const existingLookup = metadataLookups.get(lookupKey) ?? {
+        query,
+        year,
+        rawTitles: new Set<string>(),
+      }
+      existingLookup.rawTitles.add(title)
+      metadataLookups.set(lookupKey, existingLookup)
     })
 
     const uniqueTitlesAndMetadata = await pMap(
-      Array.from(
-        titleQueriesToRawTitles.values(),
-        (rawTitles) => Array.from(rawTitles)[0],
-      ).sort(),
+      Array.from(metadataLookups.values())
+        .sort((left, right) => {
+          const leftRawTitle = Array.from(left.rawTitles)[0] ?? ''
+          const rightRawTitle = Array.from(right.rawTitles)[0] ?? ''
+          return leftRawTitle.localeCompare(rightRawTitle)
+        })
+        .map((lookup) => ({
+          title: Array.from(lookup.rawTitles)[0] ?? '',
+          year: lookup.year,
+        })),
       getMetadata,
       {
         concurrency: 5,
@@ -228,8 +245,10 @@ export const scrapers = async () => {
 
     const allWithResolvedMovies = makeScreeningsUniqueAndSorted(
       allRawScreenings.map((movie) => {
+        const lookupKey = getMetadataLookupKey(movie.title, movie.year)
         const metadata = uniqueTitlesAndMetadata.find(
-          (entry) => entry.query === normalizeMovieTitleForLookup(movie.title),
+          (entry) =>
+            getMetadataLookupKey(entry.query, entry.year) === lookupKey,
         )
 
         return {
@@ -269,11 +288,14 @@ export const scrapers = async () => {
 
     const toTitleMatchRecord = (metadata) => ({
       query: metadata.query,
+      year: metadata.year,
       titleRaw: Array.from(
-        titleQueriesToRawTitles.get(metadata.query) ?? [],
+        metadataLookups.get(getMetadataLookupKey(metadata.query, metadata.year))
+          ?.rawTitles ?? [],
       )[0],
       titleRawVariants: Array.from(
-        titleQueriesToRawTitles.get(metadata.query) ?? [],
+        metadataLookups.get(getMetadataLookupKey(metadata.query, metadata.year))
+          ?.rawTitles ?? [],
       ),
       movieId: metadata.movieId,
       title: metadata.title,

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -63,4 +63,26 @@ describe('titleResolver', () => {
     expect(alternateTitleScore).toBeGreaterThan(0.9)
     expect(wrongMovieScore).toBeLessThan(0.6)
   })
+
+  test('uses an explicit year hint when provided', () => {
+    const preferredYearScore = scoreCandidate(
+      'A Family',
+      {
+        title: 'A Family',
+        releaseDate: '2026-04-02',
+      },
+      2026,
+    )
+
+    const wrongYearScore = scoreCandidate(
+      'A Family',
+      {
+        title: 'A Family',
+        releaseDate: '1970-04-02',
+      },
+      2026,
+    )
+
+    expect(preferredYearScore).toBeGreaterThan(wrongYearScore)
+  })
 })

--- a/cloud/types.ts
+++ b/cloud/types.ts
@@ -1,5 +1,6 @@
 export type Screening = {
   title: string
+  year?: number
   url: string
   cinema: string
   date: Date


### PR DESCRIPTION
## Summary
- extend the cloud  type with an optional  field
- pass the year into metadata lookup and use it as  when searching TMDB
- key metadata resolution by normalized title plus year so future same-title different-year screenings resolve independently

## Testing
- 
> expatcinema.com-cloud@1.0.1 test /Users/ckuijjer/src/expatcinema.com/cloud
> jest "titleResolver"

## Notes
- this only changes the pipeline and types for now; none of the current scrapers populate  yet