### PR TITLE
Extract years from Kino Rotterdam FK feed

### DIFF
--- a/cloud/scrapers/kinorotterdam.ts
+++ b/cloud/scrapers/kinorotterdam.ts
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { parseFkFeedYear } from './utils/parseFkFeedYear'
 import { removeYearSuffix } from './utils/removeYearSuffix'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
@@ -21,6 +22,7 @@ const extractDate = (time: string) =>
 
 type FkFeedItem = {
   title: string
+  year?: string
   language: { label: string; value: string }
   permalink: string
   times: { program_start: string; program_end: string; tags: string[] }[]
@@ -65,6 +67,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
         .map((time) => {
           return {
             title: cleanTitle(decode(movie.title)),
+            year: parseFkFeedYear(movie.year),
             url: movie.permalink,
             cinema: 'Kino',
             date: extractDate(time.program_start),

--- a/cloud/scrapers/utils/parseFkFeedYear.ts
+++ b/cloud/scrapers/utils/parseFkFeedYear.ts
@@ -1,0 +1,13 @@
+export const parseFkFeedYear = (year?: string) => {
+  if (!year) {
+    return undefined
+  }
+
+  const normalizedYear = year.trim()
+
+  if (!/^\d{4}$/.test(normalizedYear)) {
+    return undefined
+  }
+
+  return Number(normalizedYear)
+}

--- a/cloud/test/kinorotterdam.test.ts
+++ b/cloud/test/kinorotterdam.test.ts
@@ -1,0 +1,14 @@
+import { parseFkFeedYear } from '../scrapers/utils/parseFkFeedYear'
+
+describe('kinorotterdam', () => {
+  test('parses a 4-digit FK feed movie year', () => {
+    expect(parseFkFeedYear('2025')).toBe(2025)
+  })
+
+  test('returns undefined for empty or invalid FK feed movie years', () => {
+    expect(parseFkFeedYear(undefined)).toBeUndefined()
+    expect(parseFkFeedYear('')).toBeUndefined()
+    expect(parseFkFeedYear('  ')).toBeUndefined()
+    expect(parseFkFeedYear('2025/2026')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- parse the optional `year` field from the Kino Rotterdam FK feed into `Screening.year`
- keep the parsing logic in a small shared utility with focused unit coverage
- rely on the existing scraper pipeline so `screenings.json` now includes `year` whenever any cinema scraper provides it

## Testing
- `cd cloud && pnpm test -- kinorotterdam titleResolver`
- `cd cloud && pnpm prettier --check scrapers/kinorotterdam.ts scrapers/utils/parseFkFeedYear.ts test/kinorotterdam.test.ts`