### PR TITLE
Force GitHub Pages actions onto Node 24

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -15,6 +15,9 @@ on:
     - cron: '30 3 * * *' # daily at 3.30 UTC.
   workflow_dispatch: # Allows you to run this workflow manually from the Actions tab
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- force JavaScript-based actions in the `Web` workflow onto Node 24
- keep the existing Pages action set and deploy flow unchanged

## Why
GitHub is warning that Pages-related actions in this workflow are still running on Node 20. The official migration path is to set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` until those actions move their default runtime.

I checked the action majors already in use:
- `actions/configure-pages@v5`
- `actions/upload-pages-artifact@v4`
- `actions/deploy-pages@v4`

There is no newer major to adopt here without changing behavior. This PR uses GitHub's documented Node 24 override instead, which should be non-breaking because it leaves the action set and workflow logic intact.

## Testing
- workflow-only change; no local runtime checks