### PR TITLE
Extract years from scraper title text

### DIFF
--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -5,6 +5,7 @@ import XRayCrawler from 'x-ray-crawler'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { trim } from './utils/xrayFilters'
@@ -88,6 +89,7 @@ export const extractFromMoviePage = async (
   const screenings: Screening[] = movie.screenings.map((screening) => {
     return {
       title: cleanTitle(movie.title),
+      year: extractYearFromTitle(movie.title),
       url,
       cinema: 'De Uitkijk',
       date: extractDate(screening),

--- a/cloud/scrapers/kriterion.ts
+++ b/cloud/scrapers/kriterion.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 
@@ -138,6 +139,7 @@ const extractFromMainPage = async () => {
 
         const screening: Screening = {
           title: cleanTitle(item.name),
+          year: extractYearFromTitle(item.name),
           url,
           cinema: 'Kriterion',
           date: DateTime.fromISO(item.starts_at).toJSDate(),

--- a/cloud/scrapers/lab111.ts
+++ b/cloud/scrapers/lab111.ts
@@ -3,6 +3,7 @@ import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
 import xRayPuppeteer from '../xRayPuppeteer'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { guessYear } from './utils/guessYear'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
 import { runIfMain } from './utils/runIfMain'
@@ -19,8 +20,6 @@ const logger = parentLogger.createChild({
 const xray = Xray({
   filters: {
     trim,
-    cleanTitle: (value) =>
-      typeof value === 'string' ? value.replace(/\(.*\)\s+$/, '') : value,
     normalizeWhitespace: (value) =>
       typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
   },
@@ -59,7 +58,7 @@ const extractFromMainPage = async () => {
       '#programmalist .filmdetails',
       [
         {
-          title: 'h2.hidemobile a | trim | cleanTitle',
+          title: 'h2.hidemobile a | trim | normalizeWhitespace',
           url: 'h2.hidemobile a@href | trim',
           metadata: '.row.hidemobile | normalizeWhitespace',
           dates: ['.day td:first-child | trim'],
@@ -97,6 +96,7 @@ const extractFromMainPage = async () => {
 
           return {
             title: cleanTitle(movie.title),
+            year: extractYearFromTitle(movie.title),
             url: movie.url,
             cinema: 'Lab111',
             date: DateTime.fromObject({

--- a/cloud/scrapers/lantarenvenster.ts
+++ b/cloud/scrapers/lantarenvenster.ts
@@ -3,6 +3,7 @@ import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { guessYear } from './utils/guessYear'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
 import { removeYearSuffix } from './utils/removeYearSuffix'
@@ -82,6 +83,7 @@ export const extractFromMoviePage = async (
 
           return {
             title: cleanTitle(movie.title),
+            year: extractYearFromTitle(movie.title),
             url,
             cinema: 'Lantarenvenster',
             date: DateTime.fromObject({

--- a/cloud/scrapers/melkweg.ts
+++ b/cloud/scrapers/melkweg.ts
@@ -3,6 +3,7 @@ import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { removeYearSuffix } from './utils/removeYearSuffix'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
@@ -64,6 +65,7 @@ const extractFromMainPage = async () => {
     .map((event): Screening => {
       return {
         title: cleanTitle(event.attributes.name),
+        year: extractYearFromTitle(event.attributes.name),
         url: `https://www.melkweg.nl${event.attributes.url}`,
         date: DateTime.fromISO(event.attributes.startDate).toJSDate(),
         cinema: 'Melkweg',

--- a/cloud/scrapers/studiok.ts
+++ b/cloud/scrapers/studiok.ts
@@ -4,6 +4,7 @@ import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { guessYear } from './utils/guessYear'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
@@ -100,6 +101,7 @@ const extractFromMoviePage = async (url: string) => {
 
           return {
             title: cleanTitle(title),
+            year: extractYearFromTitle(title),
             url,
             cinema: 'Studio/K',
             date: DateTime.fromObject({

--- a/cloud/scrapers/utils/extractYearFromTitle.ts
+++ b/cloud/scrapers/utils/extractYearFromTitle.ts
@@ -1,0 +1,13 @@
+export const extractYearFromTitle = (title?: string) => {
+  if (!title) {
+    return undefined
+  }
+
+  const yearMatches = Array.from(
+    title.matchAll(/\((?:[^)]*?\b)?((?:19|20)\d{2})(?:\b[^)]*)?\)/g),
+  )
+
+  const matchedYear = yearMatches.at(-1)?.[1]
+
+  return matchedYear ? Number(matchedYear) : undefined
+}

--- a/cloud/test/extractYearFromTitle.test.ts
+++ b/cloud/test/extractYearFromTitle.test.ts
@@ -1,0 +1,19 @@
+import { extractYearFromTitle } from '../scrapers/utils/extractYearFromTitle'
+
+describe('extractYearFromTitle', () => {
+  test('extracts a trailing parenthetical year', () => {
+    expect(extractYearFromTitle('The Piano Teacher (2001)')).toBe(2001)
+  })
+
+  test('extracts a year from a mixed parenthetical label', () => {
+    expect(extractYearFromTitle('Funny Games (1997, ENG subs)')).toBe(1997)
+  })
+
+  test('extracts the last parenthetical year when multiple labels exist', () => {
+    expect(extractYearFromTitle('Caché (2005) (En Subs)')).toBe(2005)
+  })
+
+  test('does not treat non-parenthetical title numbers as a release year', () => {
+    expect(extractYearFromTitle('1900 (Novecento) – Part One')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- extract movie release years from raw title text before scraper-specific cleanup strips them
- add a shared utility for conservative parenthetical year parsing
- apply it to the scrapers where the raw title clearly carried year information already

## Scrapers updated
- `deuitkijk`
- `kriterion`
- `lab111`
- `lantarenvenster`
- `melkweg`
- `studiok`

## Testing
- `cd cloud && pnpm prettier --check scrapers/lantarenvenster.ts scrapers/studiok.ts scrapers/melkweg.ts scrapers/deuitkijk.ts scrapers/kriterion.ts scrapers/lab111.ts scrapers/utils/extractYearFromTitle.ts test/extractYearFromTitle.test.ts`
- `cd cloud && pnpm test -- extractYearFromTitle titleResolver`

## Local validation
Ran under `nvm use 24` from the repo root with `cd cloud`:
- `LOG_LEVEL=error pnpm tsx scrapers/lantarenvenster.ts`
- `LOG_LEVEL=error pnpm tsx scrapers/studiok.ts`
- `LOG_LEVEL=error pnpm tsx scrapers/melkweg.ts`
- `LOG_LEVEL=error pnpm tsx scrapers/deuitkijk.ts`

These all emitted screenings with `year` populated after the change.

Notes:
- `kriterion` currently returns a live `403` from `https://storage.googleapis.com/kritsite-buffer/shows.json`, so validation there was code-level only.
- `lab111` is slow/flaky under Puppeteer locally; the extraction logic is wired and covered by the shared year-extraction test, but I did not get a clean live `year` sample from that scraper within this pass.