### PR TITLE
Extract years from Cinecitta and Eye APIs

### DIFF
--- a/cloud/scrapers/cinecitta.ts
+++ b/cloud/scrapers/cinecitta.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { parseFkFeedYear } from './utils/parseFkFeedYear'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 
@@ -22,6 +23,7 @@ type WpJsonMovie = {
   title: { rendered: string }
   link: string
   movie_sync_id: number
+  release_year?: string
   language_subtitles: string
   status_other: string
 }
@@ -86,6 +88,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
           return shows.map((show) => {
             return {
               title: cleanTitle(movie),
+              year: parseFkFeedYear(movie.release_year),
               url: movie.link,
               cinema: 'Cinecitta',
               date: extractDate(show.start),

--- a/cloud/scrapers/eyefilm.ts
+++ b/cloud/scrapers/eyefilm.ts
@@ -14,6 +14,16 @@ const logger = parentLogger.createChild({
 
 const cleanTitle = (title: string) => titleCase(title)
 
+type EyeShow = {
+  url: string
+  startDateTime: string
+  singleSubtitles: string
+  production: {
+    title: string
+    year?: number | null
+  }[]
+}
+
 const extractFromGraphQL = async (): Promise<Screening[]> => {
   const client = new ApolloClient({
     link: new HttpLink({ uri: 'https://www.eyefilm.nl/graphql', fetch }),
@@ -50,6 +60,9 @@ const extractFromGraphQL = async (): Promise<Screening[]> => {
           singleSubtitles
           production {
             title
+            ... on production_production_Entry {
+              year
+            }
           }
         }
       }
@@ -62,7 +75,7 @@ const extractFromGraphQL = async (): Promise<Screening[]> => {
     .endOf('day')
     .toFormat('yyyy-MM-dd HH:mm')
 
-  const results = await client.query<{ shows: any[] }>({
+  const results = await client.query<{ shows: EyeShow[] }>({
     query,
     variables: {
       siteId: 'eyeEnglish',
@@ -81,6 +94,7 @@ const extractFromGraphQL = async (): Promise<Screening[]> => {
     .map((show) => {
       return {
         title: cleanTitle(show.production[0].title),
+        year: show.production[0].year ?? undefined,
         url: show.url,
         cinema: 'Eye',
         date: new Date(show.startDateTime),


### PR DESCRIPTION
## Summary
- set `screening.year` from Cinecitta's structured `release_year` field
- request Eye's structured `production.year` field from GraphQL and map it into screenings

## Validation
- `prettier --check` passed for the changed scraper files
- validated directly against the source APIs:
  - Cinecitta movie API returns `release_year` and `release_date`
  - Eye GraphQL returns `production.year` for current English-subtitled shows

## Notes
I used a clean worktree off `main` because the main workspace had an unrelated local edit in `cloud/scrapers/kriterion.ts`. The PR only contains the Cinecitta and Eye changes.