### PR TITLE
Add Chassé Cinema scraper

### DIFF
--- a/cloud/scrapers/chasse.ts
+++ b/cloud/scrapers/chasse.ts
@@ -1,0 +1,86 @@
+import got from 'got'
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { runIfMain } from './utils/runIfMain'
+import { titleCase } from './utils/titleCase'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'chasse',
+  },
+})
+
+const BASE_URL = 'https://www.chasse.nl'
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type XRayResult = {
+  title: string
+  url: string
+  venue: string
+  startsAt: string
+}
+
+const parseDate = (startsAt: string) => {
+  const parsed = DateTime.fromFormat(startsAt, 'yyyy-MM-dd HH:mm:ss', {
+    zone: 'Europe/Amsterdam',
+  })
+
+  if (!parsed.isValid) {
+    throw new Error(`Could not parse Chasse screening date: ${startsAt}`)
+  }
+
+  return parsed.toJSDate()
+}
+
+const cleanTitle = (title: string) =>
+  titleCase(title.replace(/^Internationals Cinema:\s*/i, '').replace(/\s*\(EN subs\)$/i, ''))
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const html = await got(
+    'https://www.chasse.nl/nl/internationals-cinema-breda-chasse-cinema-breda-13gr',
+  ).text()
+
+  const results: XRayResult[] = await xray(
+    html,
+    '.eventCard',
+    [
+      {
+        title: 'h3.title | normalizeWhitespace | trim',
+        url: 'a.desc@href',
+        venue: '.venue | normalizeWhitespace | trim',
+        startsAt: 'a.btn-order@data-event-start',
+      },
+    ],
+  )
+
+  logger.info('main page', { results })
+
+  const screenings = results
+    .filter(({ title }) => title?.toLowerCase().includes('en subs'))
+    .map(({ title, url, startsAt }) => ({
+      title: cleanTitle(title),
+      url: new URL(url, BASE_URL).toString(),
+      cinema: 'Chassé Cinema',
+      date: parseDate(startsAt),
+    }))
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -11,6 +11,7 @@ import getMetadata from '../metadata'
 import { logger } from '../powertools'
 import { Screening } from '../types'
 import bioscopenleiden from './bioscopenleiden'
+import chasse from './chasse'
 import cinecenter from './cinecenter'
 import cinecitta from './cinecitta'
 import cinemadevlugt from './cinemadevlugt'
@@ -52,6 +53,7 @@ import {
 
 const SCRAPERS = {
   bioscopenleiden,
+  chasse,
   cinecenter,
   cinecitta,
   cinemadevlugt,

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -28,6 +28,12 @@
     "logo": "filmhuisdenhaag.png"
   },
   {
+    "name": "Chassé Cinema",
+    "slug": "chasse-cinema",
+    "city": "breda",
+    "url": "https://www.chasse.nl"
+  },
+  {
     "name": "Kino",
     "slug": "kino",
     "city": "rotterdam",

--- a/web/data/city.json
+++ b/web/data/city.json
@@ -4,6 +4,7 @@
   { "name": "Den Haag", "slug": "den-haag" },
   { "name": "Utrecht", "slug": "utrecht" },
   { "name": "Arnhem", "slug": "arnhem" },
+  { "name": "Breda", "slug": "breda" },
   { "name": "Delft", "slug": "delft" },
   { "name": "Eindhoven", "slug": "eindhoven" },
   { "name": "Enschede", "slug": "enschede" },


### PR DESCRIPTION
Closes #176.

Adds a scraper for Chassé Cinema using the dedicated Internationals Cinema Breda page. The page exposes event metadata directly in the HTML, including a machine-readable `data-event-start` timestamp, so the scraper can avoid fetching individual event pages.

Current screenings found for manual validation:

- `Romería` — Sunday, April 19, 2026 at 18:30 — https://www.chasse.nl/nl/programma/internationals-cinema-romeria-en-subs-hnq3

Validation notes:

- The Internationals page currently also lists future `BUas Movie Club Selection` placeholders without explicit `EN subs` titles. This scraper only keeps entries whose title explicitly includes `EN subs`.
- Local scraper run returned exactly 1 screening on April 10, 2026.