### PR TITLE
Add Filmtheater De Witt scraper

### DIFF
--- a/cloud/scrapers/dewittdordrecht.ts
+++ b/cloud/scrapers/dewittdordrecht.ts
@@ -1,0 +1,125 @@
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { guessYear } from './utils/guessYear'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { runIfMain } from './utils/runIfMain'
+import { splitTime } from './utils/splitTime'
+import { titleCase } from './utils/titleCase'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'dewittdordrecht',
+  },
+})
+
+const BASE_URL = 'https://www.dewittdordrecht.nl'
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type XRayFromMainPage = {
+  title: string
+  url: string
+}
+
+type XRayFromMoviePage = {
+  screenings: {
+    date: string
+    times: string[]
+  }[]
+}
+
+const cleanTitle = (title: string) =>
+  titleCase(title.replace(/^Expat Cinema:\s*/i, ''))
+
+const parseDate = (date: string, time: string) => {
+  const [, dayString, monthStringWithDot] = date.split(/\s+/)
+  const day = Number(dayString)
+  const month = shortMonthToNumberDutch(monthStringWithDot.replace(/\.$/, ''))
+  const [hour, minute] = splitTime(time)
+  const year = guessYear({ day, month, hour, minute })
+
+  return DateTime.fromObject(
+    {
+      day,
+      month,
+      year,
+      hour,
+      minute,
+    },
+    {
+      zone: 'Europe/Amsterdam',
+    },
+  ).toJSDate()
+}
+
+const extractFromMoviePage = async ({
+  title,
+  url,
+}: XRayFromMainPage): Promise<Screening[]> => {
+  const movie: XRayFromMoviePage = await xray(url, {
+    screenings: xray('.showtijden', [
+      {
+        date: 'p.fw-bold | normalizeWhitespace | trim',
+        times: ['a.btn-times | normalizeWhitespace | trim'],
+      },
+    ]),
+  })
+
+  logger.info('movie page', { url, movie })
+
+  return makeScreeningsUniqueAndSorted(
+    movie.screenings.flatMap(({ date, times }) =>
+      times.map((time) => ({
+        title: cleanTitle(title),
+        url,
+        cinema: 'Filmtheater De Witt',
+        date: parseDate(date, time),
+      })),
+    ),
+  )
+}
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const results: XRayFromMainPage[] = await xray(
+    `${BASE_URL}/filmtheater/`,
+    'a.card-link',
+    [
+      {
+        title: '@title',
+        url: '@href',
+      },
+    ],
+  )
+
+  logger.info('main page', { results })
+
+  const expatCinemaPages = results
+    .filter(({ title }) => title?.toLowerCase().includes('expat cinema'))
+    .map(({ title, url }) => ({
+      title,
+      url: new URL(url, BASE_URL).toString(),
+    }))
+
+  const screenings = (
+    await Promise.all(expatCinemaPages.map(extractFromMoviePage))
+  ).flat()
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -16,6 +16,7 @@ import cinecitta from './cinecitta'
 import cinemadevlugt from './cinemadevlugt'
 import cinerama from './cinerama'
 import concordia from './concordia'
+import dewittdordrecht from './dewittdordrecht'
 import defilmhallen from './defilmhallen'
 import deuitkijk from './deuitkijk'
 import dokhuis from './dokhuis'
@@ -57,6 +58,7 @@ const SCRAPERS = {
   cinemadevlugt,
   cinerama,
   concordia,
+  dewittdordrecht,
   defilmhallen,
   deuitkijk,
   dokhuis,

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -28,6 +28,12 @@
     "logo": "filmhuisdenhaag.png"
   },
   {
+    "name": "Filmtheater De Witt",
+    "slug": "filmtheater-de-witt",
+    "city": "dordrecht",
+    "url": "https://www.dewittdordrecht.nl/filmtheater/"
+  },
+  {
     "name": "Kino",
     "slug": "kino",
     "city": "rotterdam",

--- a/web/data/city.json
+++ b/web/data/city.json
@@ -5,6 +5,7 @@
   { "name": "Utrecht", "slug": "utrecht" },
   { "name": "Arnhem", "slug": "arnhem" },
   { "name": "Delft", "slug": "delft" },
+  { "name": "Dordrecht", "slug": "dordrecht" },
   { "name": "Eindhoven", "slug": "eindhoven" },
   { "name": "Enschede", "slug": "enschede" },
   { "name": "Groningen", "slug": "groningen" },


### PR DESCRIPTION
Closes #177.

Adds a scraper for Filmtheater De Witt by discovering the current `Expat Cinema` card on `/filmtheater/` and then extracting the actual showtimes from that event page's `Tijden & tickets` modal.

Current screenings found for manual validation:

- `The History of Sound` — Friday, April 10, 2026 at 20:30 — https://www.dewittdordrecht.nl/filmtheater/expat-cinema-the-history-of-sound/

Validation notes:

- The main `/filmtheater/` page currently links one `Expat Cinema` special card.
- Local scraper run returned exactly 1 screening on April 10, 2026.