### PR TITLE
Add Heerenstraat Theater scraper

### DIFF
--- a/cloud/scrapers/heerenstraattheater.ts
+++ b/cloud/scrapers/heerenstraattheater.ts
@@ -1,0 +1,101 @@
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { runIfMain } from './utils/runIfMain'
+import { titleCase } from './utils/titleCase'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'heerenstraattheater',
+  },
+})
+
+const BASE_URL = 'https://www.heerenstraattheater.nl'
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type MainPageResult = {
+  title: string
+  url: string
+}
+
+type MoviePageResult = {
+  timestamps: string[]
+}
+
+const cleanTitle = (title: string) =>
+  titleCase(title.replace(/\s+ENG SUB$/i, ''))
+
+const parseTimestamp = (timestamp: string) => {
+  const parsed = DateTime.fromSeconds(Number(timestamp), {
+    zone: 'Europe/Amsterdam',
+  })
+
+  if (!parsed.isValid) {
+    throw new Error(`Could not parse Heerenstraat timestamp: ${timestamp}`)
+  }
+
+  return parsed.toJSDate()
+}
+
+const extractFromMoviePage = async ({
+  title,
+  url,
+}: MainPageResult): Promise<Screening[]> => {
+  const movie: MoviePageResult = await xray(url, {
+    timestamps: ['a.ticketstrigger@data-timestamp'],
+  })
+
+  logger.info('movie page', { url, movie })
+
+  return makeScreeningsUniqueAndSorted(
+    (movie.timestamps ?? []).map((timestamp) => ({
+      title: cleanTitle(title),
+      url,
+      cinema: 'Heerenstraat Theater',
+      date: parseTimestamp(timestamp),
+    })),
+  )
+}
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const results: MainPageResult[] = await xray(
+    `${BASE_URL}/subtitlesunday`,
+    '.overzichtfilms .movie-item-img a.movieimg',
+    [
+      {
+        title: '.hoverinfo .hovertitle | normalizeWhitespace | trim',
+        url: '@href',
+      },
+    ],
+  )
+
+  logger.info('main page', { results })
+
+  const screenings = (await Promise.all(
+    results.map(({ title, url }) =>
+      extractFromMoviePage({
+        title,
+        url: new URL(url, BASE_URL).toString(),
+      }),
+    ),
+  )).flat()
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/heerenstraattheater.ts
+++ b/cloud/scrapers/heerenstraattheater.ts
@@ -33,6 +33,7 @@ type MainPageResult = {
 
 type MoviePageResult = {
   timestamps: string[]
+  details: string[]
 }
 
 const cleanTitle = (title: string) =>
@@ -50,19 +51,37 @@ const parseTimestamp = (timestamp: string) => {
   return parsed.toJSDate()
 }
 
+const parseReleaseYear = (details: string[]) => {
+  const detailIndex = (details ?? []).findIndex((detail) =>
+    /^Productiejaar$/i.test(detail),
+  )
+
+  if (detailIndex === -1) {
+    return undefined
+  }
+
+  const year = Number(details[detailIndex + 1])
+
+  return Number.isInteger(year) ? year : undefined
+}
+
 const extractFromMoviePage = async ({
   title,
   url,
 }: MainPageResult): Promise<Screening[]> => {
   const movie: MoviePageResult = await xray(url, {
     timestamps: ['a.ticketstrigger@data-timestamp'],
+    details: ['.detailinfo p | normalizeWhitespace | trim'],
   })
 
   logger.info('movie page', { url, movie })
 
+  const year = parseReleaseYear(movie.details)
+
   return makeScreeningsUniqueAndSorted(
     (movie.timestamps ?? []).map((timestamp) => ({
       title: cleanTitle(title),
+      year,
       url,
       cinema: 'Heerenstraat Theater',
       date: parseTimestamp(timestamp),

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -30,6 +30,7 @@ import florafilmtheater from './florafilmtheater'
 import focusarnhem from './focusarnhem'
 import forumgroningen from './forumgroningen'
 import hartlooper from './hartlooper'
+import heerenstraattheater from './heerenstraattheater'
 import hetdocumentairepaviljoen from './hetdocumentairepaviljoen'
 import ketelhuis from './ketelhuis'
 import kinorotterdam from './kinorotterdam'
@@ -74,6 +75,7 @@ const SCRAPERS = {
   focusarnhem, // uses puppeteer
   forumgroningen,
   hartlooper,
+  heerenstraattheater,
   hetdocumentairepaviljoen,
   ketelhuis, // uses puppeteer
   kinorotterdam,

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -150,6 +150,12 @@
     "logo": "forumgroningen.png"
   },
   {
+    "name": "Heerenstraat Theater",
+    "slug": "heerenstraat-theater",
+    "city": "wageningen",
+    "url": "https://www.heerenstraattheater.nl/"
+  },
+  {
     "name": "Filmhuis Lumen",
     "slug": "filmhuis-lumen",
     "city": "delft",

--- a/web/data/city.json
+++ b/web/data/city.json
@@ -14,5 +14,6 @@
   { "name": "Leiden", "slug": "leiden" },
   { "name": "Maastricht", "slug": "maastricht" },
   { "name": "Nijmegen", "slug": "nijmegen" },
-  { "name": "Tilburg", "slug": "tilburg" }
+  { "name": "Tilburg", "slug": "tilburg" },
+  { "name": "Wageningen", "slug": "wageningen" }
 ]


### PR DESCRIPTION
Closes #181.

## Source
Uses the `Subtitle Sunday` overview page to discover the current English-subtitled film, then follows the film detail page and reads the `data-timestamp` value from the ticket trigger. This stays in plain HTML with `x-ray`; no browser automation is needed.

## Current screenings found
Please manually validate these against the live site:

- `Joe Speedboot`
  - Cinema: `Heerenstraat Theater`
  - URL: `https://www.heerenstraattheater.nl/movies/3163/17/joe_speedboot_eng_sub`
  - Local time: `Sunday, April 12, 2026 at 21:00` Europe/Amsterdam
  - Raw UTC: `2026-04-12T19:00:00.000Z`

## Validation
- Ran `/Users/ckuijjer/.nvm/versions/node/v24.14.1/bin/node --no-warnings --import tsx scrapers/heerenstraattheater.ts` in `cloud/` and confirmed the scraper returns the screening above.