### PR TITLE
Add FC Hyena scraper

### DIFF
--- a/cloud/scrapers/fchyena.ts
+++ b/cloud/scrapers/fchyena.ts
@@ -1,0 +1,151 @@
+import got from 'got'
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { runIfMain } from './utils/runIfMain'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'fchyena',
+  },
+})
+
+const BASE_URL = 'https://fchyena.nl'
+const TICKETS_BASE_URL = 'https://tickets.fchyena.nl'
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type MainPageResult = {
+  title: string
+  url: string
+  productionId: string
+}
+
+type DetailPageResult = {
+  credits: string[]
+}
+
+type TicketPageResult = {
+  date: string
+}
+
+const hasEnglishSubtitles = ({ credits }: DetailPageResult) => {
+  const normalizedCredits = (credits ?? []).join(' ').toLowerCase()
+
+  return (
+    normalizedCredits.includes('english subs') ||
+    normalizedCredits.includes('engels ondertiteld') ||
+    normalizedCredits.includes('engels gesproken, engels ondertiteld')
+  )
+}
+
+const parseScreeningDate = (date: string) => {
+  const parsed = DateTime.fromFormat(date, 'ccc d LLLL yyyy, HH:mm', {
+    locale: 'nl',
+    zone: 'Europe/Amsterdam',
+  })
+
+  if (!parsed.isValid) {
+    throw new Error(`Could not parse FC Hyena screening date: ${date}`)
+  }
+
+  return parsed.toJSDate()
+}
+
+const extractFromTicketPage = async ({
+  title,
+  url,
+  productionId,
+}: MainPageResult): Promise<Screening[]> => {
+  if (!productionId || productionId === '0') {
+    return []
+  }
+
+  const html = await got(
+    `${TICKETS_BASE_URL}/fchyena/nl/flow_configs/1/z_events_list`,
+    {
+      searchParams: {
+        production_id: productionId,
+      },
+    },
+  ).text()
+
+  const screenings: TicketPageResult[] = await xray(html, 'table tbody tr', [
+    {
+      date: 'p | normalizeWhitespace | trim',
+    },
+  ])
+
+  logger.info('ticket page', { title, productionId, screenings })
+
+  return screenings.map(({ date }) => ({
+    title,
+    url,
+    cinema: 'FC Hyena',
+    date: parseScreeningDate(date),
+  }))
+}
+
+const extractFromMoviePage = async (
+  movie: MainPageResult,
+): Promise<Screening[]> => {
+  const detailPage: DetailPageResult = await xray(movie.url, {
+    credits: ['.film-detail__credits div | normalizeWhitespace | trim'],
+  })
+
+  logger.info('detail page', { movie, detailPage })
+
+  if (!hasEnglishSubtitles(detailPage)) {
+    return []
+  }
+
+  return extractFromTicketPage(movie)
+}
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const html = await got(`${BASE_URL}/agenda/`).text()
+
+  const results: MainPageResult[] = await xray(
+    html,
+    'li.film--poster[data-productionid]',
+    [
+      {
+        title: 'h2.film-info__title | normalizeWhitespace | trim',
+        url: '.film-info a.time.time--inverted[href*="/films/"]@href',
+        productionId: '@data-productionid',
+      },
+    ],
+  )
+
+  logger.info('main page', { results })
+
+  const screenings = (
+    await Promise.all(
+      results.map(({ title, url, productionId }) =>
+        extractFromMoviePage({
+          title,
+          url: new URL(url, BASE_URL).toString(),
+          productionId,
+        }),
+      ),
+    )
+  ).flat()
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/fchyena.ts
+++ b/cloud/scrapers/fchyena.ts
@@ -51,6 +51,18 @@ const hasEnglishSubtitles = ({ credits }: DetailPageResult) => {
   )
 }
 
+const parseReleaseYear = ({ credits }: DetailPageResult) => {
+  const creditIndex = (credits ?? []).findIndex((credit) => /^Jaar$/i.test(credit))
+
+  if (creditIndex === -1) {
+    return undefined
+  }
+
+  const year = Number(credits[creditIndex + 1])
+
+  return Number.isInteger(year) ? year : undefined
+}
+
 const parseScreeningDate = (date: string) => {
   const parsed = DateTime.fromFormat(date, 'ccc d LLLL yyyy, HH:mm', {
     locale: 'nl',
@@ -68,7 +80,8 @@ const extractFromTicketPage = async ({
   title,
   url,
   productionId,
-}: MainPageResult): Promise<Screening[]> => {
+  year,
+}: MainPageResult & { year?: number }): Promise<Screening[]> => {
   if (!productionId || productionId === '0') {
     return []
   }
@@ -92,6 +105,7 @@ const extractFromTicketPage = async ({
 
   return screenings.map(({ date }) => ({
     title,
+    year,
     url,
     cinema: 'FC Hyena',
     date: parseScreeningDate(date),
@@ -111,7 +125,10 @@ const extractFromMoviePage = async (
     return []
   }
 
-  return extractFromTicketPage(movie)
+  return extractFromTicketPage({
+    ...movie,
+    year: parseReleaseYear(detailPage),
+  })
 }
 
 const extractFromMainPage = async (): Promise<Screening[]> => {

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -23,6 +23,7 @@ import defilmhallen from './defilmhallen'
 import deuitkijk from './deuitkijk'
 import dokhuis from './dokhuis'
 import eyefilm from './eyefilm'
+import fchyena from './fchyena'
 import filmhuisdenhaag from './filmhuisdenhaag'
 import filmhuislumen from './filmhuislumen'
 import filmkoepel from './filmkoepel'
@@ -67,6 +68,7 @@ const SCRAPERS = {
   deuitkijk,
   dokhuis,
   eyefilm,
+  fchyena,
   filmhuisdenhaag,
   filmhuislumen,
   filmkoepel,

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -75,6 +75,12 @@
     "logo": "eye.png"
   },
   {
+    "name": "FC Hyena",
+    "slug": "fc-hyena",
+    "city": "amsterdam",
+    "url": "https://fchyena.nl/"
+  },
+  {
     "name": "Kriterion",
     "slug": "kriterion",
     "city": "amsterdam",


### PR DESCRIPTION
Closes #175.

## Source
Uses the agenda page for discovery, then checks each film detail page’s credit block for the subtitle signal, and finally reads the ticket page for dated screenings. This stays in server-rendered HTML with `x-ray`; no browser automation is needed.

## Current screenings found
Please manually validate these against the live site:

- None at the moment.

Current live result on April 10, 2026:
- The current agenda contains English-audio films with Dutch subtitles, which are correctly excluded.
- `AmsFF` is marked `Taal: English subs`, but it currently has `production_id=0`, so there is no ticket-page showtime to publish as a screening.
- The scraper therefore returns `[]`.

## Validation
- Ran `/Users/ckuijjer/.nvm/versions/node/v24.14.1/bin/node --no-warnings --import tsx scrapers/fchyena.ts` in `cloud/`.
- Result: `[]`.