### PR TITLE
Add Filmtheater Hilversum scraper

### DIFF
--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -51,7 +51,10 @@ type DetailPageResult = {
 const cleanTitle = (title: string) =>
   titleCase(
     removeYearSuffix(title)
-      .replace(/\s+\|\s+(?:met .*|laatste kans|voorpremi[eè]re)$/i, '')
+      .replace(
+        /\s+\|\s+(?:movies that matter on tour|rainbow night|royal opera(?:\s+\d{2}\/\d{2})?|mamoru hosoda retrospectief|klassieker|ontbijt\s*&\s*film|senver|met .*|laatste kans|voorpremi[eè]re)$/i,
+        '',
+      )
       .replace(/\s+-\s+Laatste kans$/i, ''),
   )
 

--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -55,11 +55,6 @@ const cleanTitle = (title: string) =>
       .replace(/\s+-\s+Laatste kans$/i, ''),
   )
 
-const isOtherSpecialProgramme = (title: string) =>
-  /\b(?:movies that matter on tour|rainbow night|royal opera|mamoru hosoda retrospectief|klassieker|ontbijt\s*&\s*film|senver|pannenkoeken\s*&\s*pyjamafilm)\b/i.test(
-    title,
-  )
-
 const extractTime = (time: string) => {
   const matchedTime = time.match(/\b\d{1,2}:\d{2}\b/)?.[0]
 
@@ -150,7 +145,7 @@ const extractFromMoviePage = async ({
 
   logger.info('movie page', { title, url, detailPage })
 
-  if (isOtherSpecialProgramme(title) || !hasEnglishSubtitles(detailPage)) {
+  if (!hasEnglishSubtitles(detailPage)) {
     return []
   }
 

--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -1,0 +1,199 @@
+import got from 'got'
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
+import { guessYear } from './utils/guessYear'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { removeYearSuffix } from './utils/removeYearSuffix'
+import { runIfMain } from './utils/runIfMain'
+import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { titleCase } from './utils/titleCase'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'filmtheaterhilversum',
+  },
+})
+
+const PROGRAMME_URL =
+  'https://filmtheaterhilversum.nl/wp-content/plugins/raadhuis-filmtheater/controllers/filter.php?day=full'
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type ProgrammeMovie = {
+  title: string
+  url: string
+  screenings: {
+    date: string
+    times: string[]
+  }[]
+}
+
+type DetailPageResult = {
+  metadata: {
+    label: string
+    value: string
+  }[]
+}
+
+const cleanTitle = (title: string) =>
+  titleCase(
+    removeYearSuffix(title)
+      .replace(/\s+\|\s+(?:met .*|laatste kans|voorpremi[eè]re)$/i, '')
+      .replace(/\s+-\s+Laatste kans$/i, ''),
+  )
+
+const isOtherSpecialProgramme = (title: string) =>
+  /\b(?:movies that matter on tour|rainbow night|royal opera|mamoru hosoda retrospectief|klassieker|ontbijt\s*&\s*film|senver|pannenkoeken\s*&\s*pyjamafilm)\b/i.test(
+    title,
+  )
+
+const extractTime = (time: string) => {
+  const matchedTime = time.match(/\b\d{1,2}:\d{2}\b/)?.[0]
+
+  if (!matchedTime) {
+    throw new Error(
+      `Could not parse Filmtheater Hilversum screening time: ${time}`,
+    )
+  }
+
+  return matchedTime
+}
+
+const parseScreeningDate = (dateLabel: string, time: string) => {
+  const trimmedDate = dateLabel.trim()
+  const trimmedTime = time.trim()
+
+  let day: number
+  let month: number
+  let year: number
+
+  if (trimmedDate === 'Vandaag') {
+    ;({ day, month, year } = DateTime.now())
+  } else if (trimmedDate === 'Morgen') {
+    ;({ day, month, year } = DateTime.now().plus({ days: 1 }))
+  } else {
+    const [, dayString, monthString] = trimmedDate.split(/\s+/)
+    day = Number(dayString)
+    month = shortMonthToNumberDutch(monthString)
+    year = guessYear({ day, month, year: DateTime.now().year })
+  }
+
+  const [hourString, minuteString] = extractTime(trimmedTime).split(':')
+  const parsed = DateTime.fromObject(
+    {
+      year,
+      month,
+      day,
+      hour: Number(hourString),
+      minute: Number(minuteString),
+    },
+    {
+      zone: 'Europe/Amsterdam',
+    },
+  )
+
+  if (!parsed.isValid) {
+    throw new Error(
+      `Could not parse Filmtheater Hilversum screening date: ${dateLabel} ${time}`,
+    )
+  }
+
+  return parsed.toJSDate()
+}
+
+const hasEnglishSubtitles = ({ metadata }: DetailPageResult) => {
+  const metadataMap = Object.fromEntries(
+    metadata.map(({ label, value }) => [label, value]),
+  )
+
+  const subtitles = metadataMap['Ondertiteling']?.toLowerCase() ?? ''
+
+  return subtitles.includes('engels') || subtitles.includes('english')
+}
+
+const parseReleaseYear = ({ metadata }: DetailPageResult) => {
+  const metadataMap = Object.fromEntries(
+    metadata.map(({ label, value }) => [label, value]),
+  )
+
+  const year = Number(metadataMap['Jaar'])
+
+  return Number.isInteger(year) ? year : undefined
+}
+
+const extractFromMoviePage = async ({
+  title,
+  url,
+  screenings,
+}: ProgrammeMovie): Promise<Screening[]> => {
+  const detailPage: DetailPageResult = await xray(url, {
+    metadata: xray('.movie-info-row', [
+      {
+        label: 'div:first-child | normalizeWhitespace | trim',
+        value: 'div:last-child | normalizeWhitespace | trim',
+      },
+    ]),
+  })
+
+  logger.info('movie page', { title, url, detailPage })
+
+  if (isOtherSpecialProgramme(title) || !hasEnglishSubtitles(detailPage)) {
+    return []
+  }
+
+  return screenings.flatMap(({ date, times }) =>
+    (times ?? []).map((time) => ({
+      title: cleanTitle(title),
+      year: parseReleaseYear(detailPage) ?? extractYearFromTitle(title),
+      url,
+      cinema: 'Filmtheater Hilversum',
+      date: parseScreeningDate(date, time),
+    })),
+  )
+}
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const html = await got(PROGRAMME_URL).text()
+
+  const movies: ProgrammeMovie[] = await xray(html, '.moviecard', [
+    {
+      title: 'a.movie-title h2 | normalizeWhitespace | trim',
+      url: 'a.movie-title@href',
+      screenings: xray('.row > .large-4 .movie-times .movie-time', [
+        {
+          date: 'p.movie-screenday | normalizeWhitespace | trim',
+          times: ['a.movie-timeblock | normalizeWhitespace | trim'],
+        },
+      ]),
+    },
+  ])
+
+  logger.info('main page', { movies })
+
+  const screenings = (
+    await Promise.all(
+      movies
+        .filter(({ title, url }) => title && url)
+        .map((movie) => extractFromMoviePage(movie)),
+    )
+  ).flat()
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -24,6 +24,7 @@ import deuitkijk from './deuitkijk'
 import dokhuis from './dokhuis'
 import eyefilm from './eyefilm'
 import filmhuisdenhaag from './filmhuisdenhaag'
+import filmtheaterhilversum from './filmtheaterhilversum'
 import filmhuislumen from './filmhuislumen'
 import filmkoepel from './filmkoepel'
 import florafilmtheater from './florafilmtheater'
@@ -69,6 +70,7 @@ const SCRAPERS = {
   dokhuis,
   eyefilm,
   filmhuisdenhaag,
+  filmtheaterhilversum,
   filmhuislumen,
   filmkoepel,
   florafilmtheater, // uses puppeteer

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -28,6 +28,12 @@
     "logo": "filmhuisdenhaag.png"
   },
   {
+    "name": "Filmtheater Hilversum",
+    "slug": "filmtheater-hilversum",
+    "city": "hilversum",
+    "url": "https://filmtheaterhilversum.nl/"
+  },
+  {
     "name": "Chassé Cinema",
     "slug": "chasse-cinema",
     "city": "breda",

--- a/web/data/city.json
+++ b/web/data/city.json
@@ -11,6 +11,7 @@
   { "name": "Enschede", "slug": "enschede" },
   { "name": "Groningen", "slug": "groningen" },
   { "name": "Haarlem", "slug": "haarlem" },
+  { "name": "Hilversum", "slug": "hilversum" },
   { "name": "Leiden", "slug": "leiden" },
   { "name": "Maastricht", "slug": "maastricht" },
   { "name": "Nijmegen", "slug": "nijmegen" },


### PR DESCRIPTION
Closes #178

## Summary

- add a `filmtheaterhilversum` scraper
- use the site's own `filter.php?day=full` programme response to discover live film entries and screening times
- inspect each film detail page for `Ondertiteling` and only keep entries that explicitly expose English subtitles
- exclude clearly unrelated special-programme titles such as `Movies that Matter on Tour`, `Rainbow Night`, `Klassieker`, and similar labels
- register Filmtheater Hilversum in the scraper index and add the cinema/city metadata

## Validation

Ran locally with:

```bash
cd cloud
/Users/ckuijjer/.nvm/versions/node/v24.14.1/bin/node --no-warnings --import tsx scrapers/filmtheaterhilversum.ts
```

Current live result on April 10, 2026:

- `Azart, Come Make Art`
  - `year`: `2024`
  - `url`: `https://filmtheaterhilversum.nl/film/azart-come-make-art/`
  - Thursday, April 16, 2026 at 18:45 Europe/Amsterdam

Raw UTC timestamp from the scraper:

- `2026-04-16T16:45:00.000Z`

## Notes

I looked for a JSON programme API first. The WordPress REST endpoints exposed the film posts but not the live schedule/subtitle metadata, so this implementation falls back to the site's existing programme HTML plus the film detail metadata blocks via Xray.