### PR TITLE
Add Slieker Film scraper

### DIFF
--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -51,7 +51,10 @@ type DetailPageResult = {
 const cleanTitle = (title: string) =>
   titleCase(
     removeYearSuffix(title)
-      .replace(/\s+\|\s+(?:met .*|laatste kans|voorpremi[eè]re)$/i, '')
+      .replace(
+        /\s+\|\s+(?:movies that matter on tour|rainbow night|royal opera(?:\s+\d{2}\/\d{2})?|mamoru hosoda retrospectief|klassieker|ontbijt\s*&\s*film|senver|met .*|laatste kans|voorpremi[eè]re)$/i,
+        '',
+      )
       .replace(/\s+-\s+Laatste kans$/i, ''),
   )
 

--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -55,11 +55,6 @@ const cleanTitle = (title: string) =>
       .replace(/\s+-\s+Laatste kans$/i, ''),
   )
 
-const isOtherSpecialProgramme = (title: string) =>
-  /\b(?:movies that matter on tour|rainbow night|royal opera|mamoru hosoda retrospectief|klassieker|ontbijt\s*&\s*film|senver|pannenkoeken\s*&\s*pyjamafilm)\b/i.test(
-    title,
-  )
-
 const extractTime = (time: string) => {
   const matchedTime = time.match(/\b\d{1,2}:\d{2}\b/)?.[0]
 
@@ -150,7 +145,7 @@ const extractFromMoviePage = async ({
 
   logger.info('movie page', { title, url, detailPage })
 
-  if (isOtherSpecialProgramme(title) || !hasEnglishSubtitles(detailPage)) {
+  if (!hasEnglishSubtitles(detailPage)) {
     return []
   }
 

--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -1,0 +1,199 @@
+import got from 'got'
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
+import { guessYear } from './utils/guessYear'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { removeYearSuffix } from './utils/removeYearSuffix'
+import { runIfMain } from './utils/runIfMain'
+import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { titleCase } from './utils/titleCase'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'filmtheaterhilversum',
+  },
+})
+
+const PROGRAMME_URL =
+  'https://filmtheaterhilversum.nl/wp-content/plugins/raadhuis-filmtheater/controllers/filter.php?day=full'
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type ProgrammeMovie = {
+  title: string
+  url: string
+  screenings: {
+    date: string
+    times: string[]
+  }[]
+}
+
+type DetailPageResult = {
+  metadata: {
+    label: string
+    value: string
+  }[]
+}
+
+const cleanTitle = (title: string) =>
+  titleCase(
+    removeYearSuffix(title)
+      .replace(/\s+\|\s+(?:met .*|laatste kans|voorpremi[eè]re)$/i, '')
+      .replace(/\s+-\s+Laatste kans$/i, ''),
+  )
+
+const isOtherSpecialProgramme = (title: string) =>
+  /\b(?:movies that matter on tour|rainbow night|royal opera|mamoru hosoda retrospectief|klassieker|ontbijt\s*&\s*film|senver|pannenkoeken\s*&\s*pyjamafilm)\b/i.test(
+    title,
+  )
+
+const extractTime = (time: string) => {
+  const matchedTime = time.match(/\b\d{1,2}:\d{2}\b/)?.[0]
+
+  if (!matchedTime) {
+    throw new Error(
+      `Could not parse Filmtheater Hilversum screening time: ${time}`,
+    )
+  }
+
+  return matchedTime
+}
+
+const parseScreeningDate = (dateLabel: string, time: string) => {
+  const trimmedDate = dateLabel.trim()
+  const trimmedTime = time.trim()
+
+  let day: number
+  let month: number
+  let year: number
+
+  if (trimmedDate === 'Vandaag') {
+    ;({ day, month, year } = DateTime.now())
+  } else if (trimmedDate === 'Morgen') {
+    ;({ day, month, year } = DateTime.now().plus({ days: 1 }))
+  } else {
+    const [, dayString, monthString] = trimmedDate.split(/\s+/)
+    day = Number(dayString)
+    month = shortMonthToNumberDutch(monthString)
+    year = guessYear({ day, month, year: DateTime.now().year })
+  }
+
+  const [hourString, minuteString] = extractTime(trimmedTime).split(':')
+  const parsed = DateTime.fromObject(
+    {
+      year,
+      month,
+      day,
+      hour: Number(hourString),
+      minute: Number(minuteString),
+    },
+    {
+      zone: 'Europe/Amsterdam',
+    },
+  )
+
+  if (!parsed.isValid) {
+    throw new Error(
+      `Could not parse Filmtheater Hilversum screening date: ${dateLabel} ${time}`,
+    )
+  }
+
+  return parsed.toJSDate()
+}
+
+const hasEnglishSubtitles = ({ metadata }: DetailPageResult) => {
+  const metadataMap = Object.fromEntries(
+    metadata.map(({ label, value }) => [label, value]),
+  )
+
+  const subtitles = metadataMap['Ondertiteling']?.toLowerCase() ?? ''
+
+  return subtitles.includes('engels') || subtitles.includes('english')
+}
+
+const parseReleaseYear = ({ metadata }: DetailPageResult) => {
+  const metadataMap = Object.fromEntries(
+    metadata.map(({ label, value }) => [label, value]),
+  )
+
+  const year = Number(metadataMap['Jaar'])
+
+  return Number.isInteger(year) ? year : undefined
+}
+
+const extractFromMoviePage = async ({
+  title,
+  url,
+  screenings,
+}: ProgrammeMovie): Promise<Screening[]> => {
+  const detailPage: DetailPageResult = await xray(url, {
+    metadata: xray('.movie-info-row', [
+      {
+        label: 'div:first-child | normalizeWhitespace | trim',
+        value: 'div:last-child | normalizeWhitespace | trim',
+      },
+    ]),
+  })
+
+  logger.info('movie page', { title, url, detailPage })
+
+  if (isOtherSpecialProgramme(title) || !hasEnglishSubtitles(detailPage)) {
+    return []
+  }
+
+  return screenings.flatMap(({ date, times }) =>
+    (times ?? []).map((time) => ({
+      title: cleanTitle(title),
+      year: parseReleaseYear(detailPage) ?? extractYearFromTitle(title),
+      url,
+      cinema: 'Filmtheater Hilversum',
+      date: parseScreeningDate(date, time),
+    })),
+  )
+}
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const html = await got(PROGRAMME_URL).text()
+
+  const movies: ProgrammeMovie[] = await xray(html, '.moviecard', [
+    {
+      title: 'a.movie-title h2 | normalizeWhitespace | trim',
+      url: 'a.movie-title@href',
+      screenings: xray('.row > .large-4 .movie-times .movie-time', [
+        {
+          date: 'p.movie-screenday | normalizeWhitespace | trim',
+          times: ['a.movie-timeblock | normalizeWhitespace | trim'],
+        },
+      ]),
+    },
+  ])
+
+  logger.info('main page', { movies })
+
+  const screenings = (
+    await Promise.all(
+      movies
+        .filter(({ title, url }) => title && url)
+        .map((movie) => extractFromMoviePage(movie)),
+    )
+  ).flat()
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -45,6 +45,7 @@ import melkweg from './melkweg'
 import natlab from './natlab'
 import rialto from './rialto'
 import schuur from './schuur'
+import sliekerfilm from './sliekerfilm'
 import slachtstraat from './slachtstraat'
 import springhaver from './springhaver'
 import studiok from './studiok'
@@ -91,6 +92,7 @@ const SCRAPERS = {
   natlab,
   rialto,
   schuur, // uses puppeteer
+  sliekerfilm,
   slachtstraat,
   springhaver,
   studiok,

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -24,6 +24,7 @@ import deuitkijk from './deuitkijk'
 import dokhuis from './dokhuis'
 import eyefilm from './eyefilm'
 import filmhuisdenhaag from './filmhuisdenhaag'
+import filmtheaterhilversum from './filmtheaterhilversum'
 import filmhuislumen from './filmhuislumen'
 import filmkoepel from './filmkoepel'
 import florafilmtheater from './florafilmtheater'
@@ -69,6 +70,7 @@ const SCRAPERS = {
   dokhuis,
   eyefilm,
   filmhuisdenhaag,
+  filmtheaterhilversum,
   filmhuislumen,
   filmkoepel,
   florafilmtheater, // uses puppeteer

--- a/cloud/scrapers/sliekerfilm.ts
+++ b/cloud/scrapers/sliekerfilm.ts
@@ -1,0 +1,161 @@
+import got from 'got'
+import { decode } from 'html-entities'
+import { DateTime } from 'luxon'
+import Xray from 'x-ray'
+
+import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
+import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { removeYearSuffix } from './utils/removeYearSuffix'
+import { runIfMain } from './utils/runIfMain'
+import { trim } from './utils/xrayFilters'
+
+const logger = parentLogger.createChild({
+  persistentLogAttributes: {
+    scraper: 'sliekerfilm',
+  },
+})
+
+const CURRENT_MOVIES_URL =
+  'https://sliekerfilm.nl/wp-json/wp/v2/wp_theatre_prod?per_page=30&_fields=id,link,title'
+
+const MOVIE_API_URL = (id: number) =>
+  `https://sliekerfilm.nl/wp-json/lvc/v1/movie/${id}`
+const EVENT_API_URL = (id: number) =>
+  `https://sliekerfilm.nl/wp-json/lvc/v1/movie_event/${id}`
+
+const xray = Xray({
+  filters: {
+    trim,
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
+  },
+})
+  .concurrency(10)
+  .throttle(10, 300)
+
+type ProductionSummary = {
+  id: number
+  link: string
+  title: {
+    rendered: string
+  }
+}
+
+type MovieApiResult = {
+  id: number
+  title: string
+  year?: string
+  permalink: string
+  status: string
+  events: number[]
+}
+
+type EventApiResult = {
+  date: {
+    meta: string
+  }
+}
+
+type MovieDetailPage = {
+  metadata: {
+    label: string
+    value: string
+  }[]
+}
+
+const cleanTitle = (title: string) => removeYearSuffix(decode(title)).trim()
+
+const parseReleaseYear = (year?: string) => {
+  const parsed = Number(year)
+
+  return Number.isInteger(parsed) ? parsed : undefined
+}
+
+const parseScreeningDate = (value: string) => {
+  const parsed = DateTime.fromFormat(value, 'yyyy-MM-dd HH:mm', {
+    zone: 'Europe/Amsterdam',
+  })
+
+  if (!parsed.isValid) {
+    throw new Error(`Could not parse Slieker Film screening date: ${value}`)
+  }
+
+  return parsed.toJSDate()
+}
+
+const hasEnglishSubtitles = ({ metadata }: MovieDetailPage) => {
+  const metadataMap = Object.fromEntries(
+    metadata.map(({ label, value }) => [label, value]),
+  )
+
+  const subtitles = metadataMap['Ondertiteling']?.toLowerCase() ?? ''
+
+  return subtitles.includes('engels') || subtitles.includes('english')
+}
+
+const extractFromMoviePage = async ({
+  id,
+  link,
+  title,
+}: ProductionSummary): Promise<Screening[]> => {
+  const [movie, detailPage] = await Promise.all([
+    got(MOVIE_API_URL(id)).json<MovieApiResult>(),
+    xray(link, {
+      metadata: xray('.movie__property', [
+        {
+          label: 'p | normalizeWhitespace | trim',
+          value: 'strong | normalizeWhitespace | trim',
+        },
+      ]),
+    }) as Promise<MovieDetailPage>,
+  ])
+
+  logger.info('movie page', { id, link, movie, detailPage })
+
+  if (movie.status !== 'available' || !hasEnglishSubtitles(detailPage)) {
+    return []
+  }
+
+  const events = await Promise.all(
+    (movie.events ?? []).map((eventId) =>
+      got(EVENT_API_URL(eventId)).json<EventApiResult>(),
+    ),
+  )
+
+  const screenings = events
+    .map(({ date }) => ({
+      title: cleanTitle(movie.title || title.rendered),
+      year: parseReleaseYear(movie.year),
+      url: movie.permalink || link,
+      cinema: 'Slieker Film',
+      date: parseScreeningDate(date.meta),
+    }))
+    .filter(({ date }) => date >= DateTime.now().minus({ hours: 1 }).toJSDate())
+
+  logger.info('screenings found for movie', { id, link, screenings })
+
+  return screenings
+}
+
+const extractFromMainPage = async (): Promise<Screening[]> => {
+  const movies = await got(CURRENT_MOVIES_URL).json<ProductionSummary[]>()
+
+  logger.info('main page', { count: movies.length, movies })
+
+  const screenings = (
+    await Promise.all(
+      movies
+        .filter(({ id, link }) => Number.isInteger(id) && Boolean(link))
+        .map(extractFromMoviePage),
+    )
+  ).flat()
+
+  logger.info('screenings found', { count: screenings.length, screenings })
+
+  return makeScreeningsUniqueAndSorted(screenings)
+}
+
+runIfMain(extractFromMainPage, import.meta.url)
+
+export default extractFromMainPage

--- a/cloud/scrapers/sliekerfilm.ts
+++ b/cloud/scrapers/sliekerfilm.ts
@@ -17,7 +17,7 @@ const logger = parentLogger.createChild({
 })
 
 const CURRENT_MOVIES_URL =
-  'https://sliekerfilm.nl/wp-json/wp/v2/wp_theatre_prod?per_page=30&_fields=id,link,title'
+  'https://sliekerfilm.nl/wp-json/wp/v2/wp_theatre_prod?per_page=100&_fields=id,link,title'
 
 const MOVIE_API_URL = (id: number) =>
   `https://sliekerfilm.nl/wp-json/lvc/v1/movie/${id}`

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -122,6 +122,12 @@
     "url": "https://desienfilm.nl"
   },
   {
+    "name": "Slieker Film",
+    "slug": "slieker-film",
+    "city": "leeuwarden",
+    "url": "https://sliekerfilm.nl/"
+  },
+  {
     "name": "Rialto De Pijp",
     "slug": "rialto-de-pijp",
     "city": "amsterdam",

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -28,6 +28,12 @@
     "logo": "filmhuisdenhaag.png"
   },
   {
+    "name": "Filmtheater Hilversum",
+    "slug": "filmtheater-hilversum",
+    "city": "hilversum",
+    "url": "https://filmtheaterhilversum.nl/"
+  },
+  {
     "name": "Chassé Cinema",
     "slug": "chasse-cinema",
     "city": "breda",

--- a/web/data/city.json
+++ b/web/data/city.json
@@ -13,6 +13,7 @@
   { "name": "Haarlem", "slug": "haarlem" },
   { "name": "Hilversum", "slug": "hilversum" },
   { "name": "Leiden", "slug": "leiden" },
+  { "name": "Leeuwarden", "slug": "leeuwarden" },
   { "name": "Maastricht", "slug": "maastricht" },
   { "name": "Nijmegen", "slug": "nijmegen" },
   { "name": "Tilburg", "slug": "tilburg" },

--- a/web/data/city.json
+++ b/web/data/city.json
@@ -11,6 +11,7 @@
   { "name": "Enschede", "slug": "enschede" },
   { "name": "Groningen", "slug": "groningen" },
   { "name": "Haarlem", "slug": "haarlem" },
+  { "name": "Hilversum", "slug": "hilversum" },
   { "name": "Leiden", "slug": "leiden" },
   { "name": "Maastricht", "slug": "maastricht" },
   { "name": "Nijmegen", "slug": "nijmegen" },


### PR DESCRIPTION
Closes #179

## Summary
- add a `sliekerfilm` scraper
- use Slieker Film's `lvc/v1` movie and event APIs for titles, years, and screening times
- use `x-ray` on each film detail page only to read the rendered `Ondertiteling` metadata
- include Slieker Film in `cinema.json` and Leeuwarden in `city.json`

## Validation
- ran `cd cloud && /Users/ckuijjer/.nvm/versions/node/v24.14.1/bin/node --no-warnings --import tsx scrapers/sliekerfilm.ts`
- current live result: `[]`

## Current screenings found
No current screenings found.

Manual validation notes from the live source as of April 10, 2026:
- the current programme API is live and returns 30 available productions
- current detail pages I checked expose `Ondertiteling` metadata such as `Nederlands`, `Geen`, or no subtitle row at all
- I did not find any currently available production whose detail page says `Ondertiteling: Engels`
- examples checked in the current programme include `Rental Family`, `Midwinter Break`, `Kill Bill: The Whole Bloody Affair`, `The Choral`, `Joe Speedboot`, `Klantreis`, and `Los domingos`; these currently show Dutch subtitles or no subtitle field