### PR TITLE
Clean up Filmhuis Den Haag and Kino title noise

### DIFF
--- a/cloud/scrapers/filmhuisdenhaag.ts
+++ b/cloud/scrapers/filmhuisdenhaag.ts
@@ -69,7 +69,10 @@ const cleanTitle = (title: string) =>
   titleCase(
     title
       .replace(/ - EN subs$/i, '') // remove subs from the title
-      .replace(/ -(.*?)$/, ''), // actually remove the last dash and everything after it (bit questionable)
+      .replace(
+        /\s+\((?:4K Restoration|Re-Release)\)(?:\s+-\s+Late Night Anime)?$/i,
+        '',
+      ), // remove presentation-only suffixes
   )
 
 const hasEnglishSubtitles = (item) => {

--- a/cloud/scrapers/kinorotterdam.ts
+++ b/cloud/scrapers/kinorotterdam.ts
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { parseFkFeedYear } from './utils/parseFkFeedYear'
 import { removeYearSuffix } from './utils/removeYearSuffix'
 import { runIfMain } from './utils/runIfMain'
@@ -49,8 +50,23 @@ const removeSpecialPrefix = (title: string) => {
   return title.replace(/^kinoxeur:\s+/i, '')
 }
 
+const removeSpecialSuffixes = (title: string) => {
+  return title
+    .replace(/\s+[0-9]+th anniversary$/i, '')
+    .replace(/\s+[–-]\s+part 1 & 2$/i, '')
+    .replace(/\s+[–-]\s+a 70mm presentation$/i, '')
+}
+
+const normalizeAcronyms = (title: string) => {
+  return title.replace(/\b(?:[A-Za-z]\.){2,}[A-Za-z]\.?/g, (match) =>
+    match.toUpperCase(),
+  )
+}
+
 const cleanTitle = (title: string) => {
-  return titleCase(removeYearSuffix(removeSpecialPrefix(title)))
+  return normalizeAcronyms(
+    titleCase(removeYearSuffix(removeSpecialSuffixes(removeSpecialPrefix(title)))),
+  )
 }
 
 const extractFromMainPage = async (): Promise<Screening[]> => {
@@ -67,7 +83,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
         .map((time) => {
           return {
             title: cleanTitle(decode(movie.title)),
-            year: parseFkFeedYear(movie.year),
+            year: parseFkFeedYear(movie.year) ?? extractYearFromTitle(movie.title),
             url: movie.permalink,
             cinema: 'Kino',
             date: extractDate(time.program_start),


### PR DESCRIPTION
## Summary
- clean Filmhuis Den Haag title suffixes for the affected `4K Restoration` and `Re-Release` cases
- clean Kino presentation/programme suffixes while preserving title acronyms
- extract years from Kino title suffixes when the feed title contains them

## Local validation
Confirmed locally under Node 24:

Filmhuis Den Haag
- `Il Conformista (4K Restoration)` -> `Il Conformista`
- `Kiki's Delivery Service (Re-Release) - Late Night Anime` -> `Kiki's Delivery Service`

Kino
- `Harlan County U.S.a. (1976) 50Th Anniversary` -> `Harlan County U.S.A.` with `year: 1976`
- `Trenque Lauquen (2022) – part 1 & 2` -> `Trenque Lauquen` with `year: 2022`
- `Kill Bill: the Whole Bloody Affair (2006) - a 70Mm Presentation` -> `Kill Bill: the Whole Bloody Affair` with `year: 2006`

## Notes
- this is one combined cleanup PR for the Filmhuis Den Haag and Kino title/year cases you listed
- I did not deploy anything