### PR TITLE
Extract Filmhuis Den Haag release years

### DIFF
--- a/cloud/scrapers/filmhuisdenhaag.ts
+++ b/cloud/scrapers/filmhuisdenhaag.ts
@@ -1,5 +1,6 @@
 import got from 'got'
 import { DateTime } from 'luxon'
+import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
@@ -11,6 +12,13 @@ import { titleCase } from './utils/titleCase'
 const logger = parentLogger.createChild({
   persistentLogAttributes: {
     scraper: 'filmhuisdenhaag',
+  },
+})
+
+const xray = Xray({
+  filters: {
+    normalizeWhitespace: (value) =>
+      typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
   },
 })
 
@@ -83,6 +91,14 @@ const hasEnglishSubtitles = (item) => {
   )
 }
 
+const parseReleaseYear = (metadata: string[]) => {
+  const match = metadata
+    .map((entry) => entry.match(/\b((?:19|20)\d{2})\b/))
+    .find(Boolean)
+
+  return match?.[1] ? Number(match[1]) : undefined
+}
+
 const extractFromMainPage = async (): Promise<Screening[]> => {
   const apiResponse: FilmhuisDenhaagAPIResponse = await got(
     'https://filmhuisdenhaag.nl/api/program',
@@ -102,6 +118,20 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       }))
     })
 
+  const releaseYearByUrl = new Map(
+    await Promise.all(
+      Array.from(
+        new Set(programs.map((item) => `https://filmhuisdenhaag.nl${item.uri}`)),
+      ).map(async (url) => {
+        const detailPage = await xray(url, {
+          metadata: ['aside .flex.flex-col.space-y-2 p | normalizeWhitespace'],
+        })
+
+        return [url, parseReleaseYear(detailPage.metadata ?? [])] as const
+      }),
+    ),
+  )
+
   const screenings: Screening[] = programs
     .filter(hasEnglishSubtitles)
     .map((item) => {
@@ -112,6 +142,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
       return {
         title: cleanTitle(item.title),
+        year: releaseYearByUrl.get(`https://filmhuisdenhaag.nl${item.uri}`),
         url: `https://filmhuisdenhaag.nl${item.uri}`,
         cinema: 'Filmhuis Den Haag',
         date: DateTime.fromObject({


### PR DESCRIPTION
Closes #244

## Summary
- extract release years from Filmhuis Den Haag detail-page metadata
- attach the parsed year to matching screenings

## Validation
- ran the Filmhuis Den Haag scraper logic locally under Node 24
- validated the live `A Family` detail page metadata path used by the scraper
- current page exposes `Nederland , 2026`, which the scraper now parses as `year: 2026`

## Notes
- the issue example `Wolf Children` currently returns `404` on the live site, so validation was done against the current live `A Family` page instead