### PR TITLE
Prefer De Uitkijk metadata years

### DIFF
--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -43,6 +43,13 @@ const xray = Xray({
 const hasEnglishSubtitles = ({ metadata }: { metadata: string[] }) =>
   metadata.some((x) => x.match(/ondertiteling:\s*engels/i))
 
+const parseReleaseYear = (metadata: string[]) => {
+  const jaarField = metadata.find((entry) => /^jaar:/i.test(entry))
+  const match = jaarField?.match(/\b((?:19|20)\d{2})\b/)
+
+  return match?.[1] ? Number(match[1]) : undefined
+}
+
 // 31-10-22-16:30
 const extractDate = (time: string) =>
   DateTime.fromFormat(time, 'dd-MM-yy-HH:mm').toJSDate()
@@ -89,7 +96,7 @@ export const extractFromMoviePage = async (
   const screenings: Screening[] = movie.screenings.map((screening) => {
     return {
       title: cleanTitle(movie.title),
-      year: extractYearFromTitle(movie.title),
+      year: parseReleaseYear(movie.metadata) ?? extractYearFromTitle(movie.title),
       url,
       cinema: 'De Uitkijk',
       date: extractDate(screening),


### PR DESCRIPTION
Closes #249

## Summary
- extract release years from the De Uitkijk `Jaar:` metadata row
- keep title-based extraction as a fallback when the metadata row is missing

## Validation
- ran the De Uitkijk scraper locally under Node 24
- confirmed current live outputs now use metadata years where available
- examples from the live run:
  - `Kiki's Delivery Service` -> `year: 1989`
  - `Rock'n'roll Ringo` -> `year: 2024`
  - `Caché` -> `year: 2005`