### PR TITLE
Extract Filmhuis Lumen release years

### DIFF
--- a/cloud/scrapers/filmhuislumen.ts
+++ b/cloud/scrapers/filmhuislumen.ts
@@ -45,6 +45,7 @@ type XRayFromMoviePage = {
   title: string
   language: string
   subtitles: string
+  year: string
   screenings: {
     date: string
     times: string[]
@@ -95,6 +96,7 @@ const extractFromMoviePage = async ({
     title: 'h1.wp-block-post-title | cleanTitle | trim',
     language: 'p.field-language .value | normalizeWhitespace | trim',
     subtitles: 'p.field-subtitles .value | normalizeWhitespace | trim',
+    year: 'p.field-year .value | normalizeWhitespace | trim',
     screenings: xray('#voorstellingen .wp-block-group:has(> .datum-tekst)', [
       {
         date: '.datum-tekst | normalizeWhitespace | trim',
@@ -113,6 +115,7 @@ const extractFromMoviePage = async ({
     .filter(({ date }) => date) // skip rows without a date (e.g. separator divs)
     .flatMap(({ date, times }) => {
       const { day, month, year } = parseDate(date)
+      const releaseYear = Number(movie.year) || undefined
 
       return (times ?? []).map((time) => {
         const [hourStr, minuteStr] = time.split(':')
@@ -121,6 +124,7 @@ const extractFromMoviePage = async ({
 
         return {
           title: movie.title,
+          year: releaseYear,
           url,
           cinema: 'Filmhuis Lumen',
           date: DateTime.fromObject({


### PR DESCRIPTION
Closes #251

## Summary
- extract release years from the Filmhuis Lumen `Jaar` field on film detail pages
- include that year on returned screenings

## Validation
- ran the Filmhuis Lumen scraper locally under Node 24
- confirmed current live outputs now include years
- examples from the live run:
  - `Sirat` -> `year: 2026`
  - `Wolf Children` -> `year: 2026`
  - `Il Conformista` -> `year: 2026`
- also validated the live page markup for `Sirat`, which exposes `<strong>Jaar</strong>` with `field-year -> 2026`