### PR TITLE
Extract Flora release years

### DIFF
--- a/cloud/scrapers/florafilmtheater.ts
+++ b/cloud/scrapers/florafilmtheater.ts
@@ -60,6 +60,14 @@ const hasEnglishSubtitles = (movie: XRayFromMainPage) => {
   return movie.metadata.includes('EN SUBS')
 }
 
+const extractMetadataYear = (metadata: string[]) => {
+  const match = metadata
+    .map((entry) => entry.match(/\b((?:19|20)\d{2})\b/))
+    .find(Boolean)
+
+  return match?.[1] ? Number(match[1]) : undefined
+}
+
 const splitDate = (date: string) => {
   if (date === 'Vandaag') {
     const { day, month, year } = DateTime.now()
@@ -122,7 +130,9 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
           return {
             title: movie.title,
-            year: extractYearFromTitle(movie.rawTitle),
+            year:
+              extractMetadataYear(movie.metadata) ??
+              extractYearFromTitle(movie.rawTitle),
             url: movie.url,
             cinema: 'Flora Filmtheater',
             date: DateTime.fromObject({


### PR DESCRIPTION
Closes #253

## Summary
- extract release years from Flora agenda metadata when available
- keep title-based extraction as a fallback for cases where the year only appears in the title

## Validation
- attempted to run the Flora scraper locally under Node 24
- local scraper execution is still blocked here by the existing Chromium `spawn ENOEXEC` issue in this environment
- validated the live agenda markup directly instead
- current live examples in the agenda HTML include:
  - `A Family - EN subs` with metadata entry `2026`
  - `Mystery Train (1989) - EN subs` with metadata entry `1989`