### PR TITLE
Extract Ketelhuis release years

### DIFF
--- a/cloud/scrapers/ketelhuis.ts
+++ b/cloud/scrapers/ketelhuis.ts
@@ -102,6 +102,13 @@ const hasEnglishSubtitles = ({ metadata, mainContent, title }) =>
   metadata?.toLowerCase().includes('engels ondertiteld') ||
   mainContent?.toLowerCase().includes('engels ondertiteld')
 
+const extractReleaseYear = (metadata: string) => {
+  const match = metadata.match(/(?:^|\s)Jaar\s*(?:19|20)\d{2}\b/i)
+  const year = match?.[0].match(/\b((?:19|20)\d{2})\b/)
+
+  return year?.[1] ? Number(year[1]) : undefined
+}
+
 const splitFirstDate = (date: string) => {
   if (date === 'Vandaag') {
     const { day, month, year } = DateTime.now()
@@ -179,11 +186,14 @@ const extractFromMoviePage = async ({ url, title }) => {
     })
   })
 
+  const releaseYear = extractReleaseYear(scrapeResult.metadata ?? '')
+
   const screenings = [...firstDates, ...otherDates].map((date) => ({
     date,
     url,
     cinema: 'Ketelhuis',
     title,
+    year: releaseYear,
   }))
 
   logger.info('screenings', { screenings })


### PR DESCRIPTION
Closes #252

## Summary
- extract release years from the Ketelhuis detail-page metadata table
- include that year on returned screenings

## Validation
- attempted to run the Ketelhuis scraper locally under Node 24
- local scraper execution is still blocked here by the existing Chromium `spawn ENOEXEC` issue in this environment
- validated the live page markup directly instead
- current `https://www.ketelhuis.nl/films/joe-speedboot-english-subs/` markup includes:
  - `Jaar` -> `2025`
  - the scraper already captures the enclosing `c-detail-info__filminfo` block, which now gets parsed into `screening.year`