### PR TITLE
Add manual override for Kino A Family

### DIFF
--- a/cloud/metadata/manualTitleOverrides.ts
+++ b/cloud/metadata/manualTitleOverrides.ts
@@ -12,7 +12,14 @@ export type ManualTitleOverride = ManualTitleOverrideInput & {
   query: string
 }
 
-const rawOverrides: ManualTitleOverrideInput[] = []
+const rawOverrides: ManualTitleOverrideInput[] = [
+  {
+    title: 'A Family',
+    year: 2024,
+    tmdbId: 1359694,
+    note: 'Kino returns the wrong release year for A Family; force the 2026 TMDB match.',
+  },
+]
 
 export const manualTitleOverrides: ManualTitleOverride[] = rawOverrides.map(
   (override) => ({


### PR DESCRIPTION
Add a year-specific manual override for Kino's `A Family` screening.

Kino currently returns `A Family` with `year: 2024`, but the screening should resolve to the 2026 TMDB movie (`tmdb:1359694`). This override forces that match for the Kino-specific year while leaving the other `A Family` variants untouched.

Validation:
- `getManualTitleOverride('A Family', 2024)` returns the Kino override with `tmdbId: 1359694`