### PR TITLE
Title-case resolved movie titles in movies.json

### DIFF
--- a/cloud/metadata/searchMetadata.ts
+++ b/cloud/metadata/searchMetadata.ts
@@ -3,6 +3,7 @@ import leven from 'leven'
 import getTmdbClient from '../clients/tmdb'
 import { logger } from '../powertools'
 import { getManualTitleOverride } from './manualTitleOverrides'
+import { titleCase } from '../scrapers/utils/titleCase'
 import {
   getTmdbSearchYears,
   mergeTmdbSearchResults,
@@ -92,9 +93,11 @@ const buildResolvedMetadata = (
   tmdbMovie: TmdbMovieResult,
   match: Metadata['match'],
 ): Omit<Metadata, 'query' | 'createdAt'> => {
-  const winningTitle = [tmdbMovie.title, tmdbMovie.originalTitle].sort(
-    (b, a) => leven(b ?? '', title) - leven(a ?? '', title),
-  )[0]
+  const winningTitle = titleCase(
+    [tmdbMovie.title, tmdbMovie.originalTitle].sort(
+      (b, a) => leven(b ?? '', title) - leven(a ?? '', title),
+    )[0] ?? title,
+  )
 
   return {
     movieId: getMovieId(tmdbMovie.id),


### PR DESCRIPTION
Apply the repo's `titleCase(...)` helper to the resolved `movies.json` `title` field.

This does not affect matching. It only changes the canonical movie title written after TMDB resolution so the public movie metadata is more consistently formatted.

Validation:
- `cd cloud && pnpm test -- --runInBand test/searchMetadata.test.ts test/titleResolver.test.ts`