### PR TITLE
Use movie titles in web screenings

### DIFF
--- a/web/utils/getScreenings.ts
+++ b/web/utils/getScreenings.ts
@@ -12,6 +12,7 @@ type ScreeningData = {
 
 type MovieData = {
   movieId: string
+  title: string
   tmdb?: {
     releaseDate?: string | null
     posterPath?: string | null
@@ -70,6 +71,7 @@ export const getScreenings = async () => {
 
     return {
       ...screening,
+      title: movie?.title ?? screening.title,
       year: movieYear ?? screening.year,
       cinema,
       posterUrl: screening.movieId


### PR DESCRIPTION
This changes the web rendering to prefer the canonical `movies.json` title whenever a screening has a resolved `movieId`.

Behavior:
- if `screening.movieId` resolves to a movie, the web now shows `movies.json` `title`
- if there is no resolved movie, it falls back to `screening.title`
- the existing release-year behavior remains unchanged

Validation:
- `cd web && PUBLIC_BUCKET=expatcinema-public-prod pnpm build`