### PR TITLE
Add movie slugs to cloud metadata

### DIFF
--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -94,6 +94,11 @@ export const getMovieId = (tmdbId: number) => `tmdb:${tmdbId}`
 export const getMetadataLookupKey = (title: string, year?: number) =>
   `${normalizeMovieTitleForLookup(title)}::${year ?? ''}`
 
+export const slugifyMovieTitle = (title: string) =>
+  normalizeMovieTitleForLookup(title)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
 type ScoreCandidateInput = {
   title?: string
   originalTitle?: string

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -56,6 +56,7 @@ import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSo
 import {
   getMetadataLookupKey,
   normalizeMovieTitleForLookup,
+  slugifyMovieTitle,
 } from '../metadata/titleResolver'
 
 const SCRAPERS = {
@@ -341,6 +342,7 @@ export const scrapers = async () => {
             metadata.movieId,
             {
               movieId: metadata.movieId,
+              slug: slugifyMovieTitle(metadata.title ?? ''),
               tmdbId: metadata.tmdb?.id,
               imdbId: metadata.imdbId,
               title: metadata.title,

--- a/cloud/test/movieSlug.test.ts
+++ b/cloud/test/movieSlug.test.ts
@@ -1,0 +1,20 @@
+import { slugifyMovieTitle } from '../metadata/titleResolver'
+
+describe('slugifyMovieTitle', () => {
+  test('slugifies a simple title', () => {
+    expect(slugifyMovieTitle('A Family')).toBe('a-family')
+  })
+
+  test('strips punctuation and diacritics', () => {
+    expect(slugifyMovieTitle('Sirāt')).toBe('sirat')
+    expect(slugifyMovieTitle("Kiki's Delivery Service")).toBe(
+      'kiki-s-delivery-service',
+    )
+  })
+
+  test('collapses noisy separators', () => {
+    expect(slugifyMovieTitle('The Wolf, the Fox and the Leopard')).toBe(
+      'the-wolf-the-fox-and-the-leopard',
+    )
+  })
+})


### PR DESCRIPTION
Adds `slug` to `movies.json` so the web movie routes can rely on canonical slugs emitted by cloud.

Validation:
- `cd cloud && pnpm test -- --runInBand test/movieSlug.test.ts test/titleResolver.test.ts`