### PR TITLE
[codex] Link posters to base movie pages

### DIFF
--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -120,6 +120,7 @@ export const ScreeningRow = ({
   year,
   cinema,
   movieId,
+  movieSlug,
   posterUrl,
   showCity = true,
 }: {
@@ -129,14 +130,15 @@ export const ScreeningRow = ({
   year?: number
   cinema: Cinema
   movieId?: string
+  movieSlug?: string
   posterUrl?: string
   showCity?: boolean
 }) => {
   const movieIdClassName = movieId
     ? `movie-id-${movieId.replace(/[^a-zA-Z0-9_-]/g, '-')}`
     : undefined
-  const tmdbUrl = movieId?.startsWith('tmdb:')
-    ? `https://www.themoviedb.org/movie/${movieId.slice(5)}`
+  const movieUrl = movieSlug
+    ? `/movie/${movieSlug}`
     : undefined
 
   return (
@@ -154,13 +156,8 @@ export const ScreeningRow = ({
             {showCity ? <> | {cinema.city.name}</> : null}
           </div>
         </a>
-        {posterUrl && tmdbUrl ? (
-          <a
-            href={tmdbUrl}
-            target="_blank"
-            rel="noreferrer"
-            className={posterLinkStyle}
-          >
+        {posterUrl && movieUrl ? (
+          <a href={movieUrl} className={posterLinkStyle}>
             <Image
               src={posterUrl}
               width={48}

--- a/web/utils/getScreenings.ts
+++ b/web/utils/getScreenings.ts
@@ -12,6 +12,7 @@ type ScreeningData = {
 
 type MovieData = {
   movieId: string
+  slug?: string
   title: string
   tmdb?: {
     releaseDate?: string | null
@@ -36,6 +37,7 @@ export type Screening = {
   cinema: Cinema
   date: string
   movieId?: string
+  movieSlug?: string
   posterUrl?: string
   title: string
   url: string
@@ -74,6 +76,7 @@ export const getScreenings = async () => {
       title: movie?.title ?? screening.title,
       year: movieYear ?? screening.year,
       cinema,
+      movieSlug: movie?.slug,
       posterUrl: screening.movieId
         ? getTmdbPosterUrl(movie?.tmdb?.posterPath)
         : undefined,


### PR DESCRIPTION
Poster clicks now always go to the base movie route (`/movie/<slug>`) when a resolved movie slug is available, regardless of city or cinema filter state.

The screening row text remains unchanged. This change just updates the poster link target and wires `movies.json.slug` through the web screening data so the poster can resolve to the canonical movie page.

Validation:
- `cd web && PUBLIC_BUCKET=expatcinema-public-prod pnpm build`