### PR TITLE
Link screening posters to canonical movie pages

### DIFF
--- a/web/components/Calendar/DirectCalendar.tsx
+++ b/web/components/Calendar/DirectCalendar.tsx
@@ -7,26 +7,16 @@ import { ScreeningRow } from '../Screening'
 export const DirectCalendar = ({
   rows,
   showCity,
-  currentCity,
-  currentCinema,
 }: {
   rows: Row[]
   showCity: boolean
-  currentCity?: string
-  currentCinema?: string
 }) => (
   <>
     {rows.map((row, i) =>
       row.component === 'RelativeDate' ? (
         <RelativeDate key={i} {...row.props} />
       ) : (
-        <ScreeningRow
-          key={i}
-          {...row.props}
-          showCity={showCity}
-          currentCity={currentCity}
-          currentCinema={currentCinema}
-        />
+        <ScreeningRow key={i} {...row.props} showCity={showCity} />
       ),
     )}
   </>

--- a/web/components/Calendar/index.tsx
+++ b/web/components/Calendar/index.tsx
@@ -117,12 +117,7 @@ export const Calendar = ({
           {emptyStateMessage}
         </h3>
       ) : (
-        <DirectCalendar
-          rows={rows}
-          showCity={showCity}
-          currentCity={currentCity}
-          currentCinema={currentCinema}
-        />
+        <DirectCalendar rows={rows} showCity={showCity} />
       )}
     </div>
   )

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -129,8 +129,6 @@ export const ScreeningRow = ({
   movieSlug,
   posterUrl,
   showCity = true,
-  currentCity,
-  currentCinema,
 }: {
   url: string
   date: DateTime
@@ -141,8 +139,6 @@ export const ScreeningRow = ({
   movieSlug?: string
   posterUrl?: string
   showCity?: boolean
-  currentCity?: string
-  currentCinema?: string
 }) => {
   const movieIdClassName = movieId
     ? `movie-id-${movieId.replace(/[^a-zA-Z0-9_-]/g, '-')}`
@@ -150,21 +146,21 @@ export const ScreeningRow = ({
   const tmdbUrl = movieId?.startsWith('tmdb:')
     ? `https://www.themoviedb.org/movie/${movieId.slice(5)}`
     : undefined
-  const movieUrl = movieSlug
-    ? currentCity && currentCinema
-      ? `/city/${currentCity}/cinema/${currentCinema}/movie/${movieSlug}`
-      : currentCity
-        ? `/city/${currentCity}/movie/${movieSlug}`
-        : `/movie/${movieSlug}`
-    : undefined
+  const movieUrl = movieSlug ? `/movie/${movieSlug}` : undefined
 
   return (
     <div className={movieIdClassName}>
       <div className={containerStyle}>
-        <a href={url} className={`${aStyle} ${screeningLinkStyle} ${timeStyle}`}>
+        <a
+          href={url}
+          className={`${aStyle} ${screeningLinkStyle} ${timeStyle}`}
+        >
           <Time>{date}</Time>
         </a>
-        <a href={url} className={`${aStyle} ${screeningLinkStyle} ${contentStyle}`}>
+        <a
+          href={url}
+          className={`${aStyle} ${screeningLinkStyle} ${contentStyle}`}
+        >
           <div className={titleStyle}>
             {title}
             {year ? <span className={titleYearStyle}> ({year})</span> : null}


### PR DESCRIPTION
This changes screening poster links to always point at the canonical movie route (`/movie/<slug>`), regardless of any current city or cinema filter.

Checks:
- `pnpm --dir web exec prettier --check components/Screening.tsx components/Calendar/DirectCalendar.tsx components/Calendar/index.tsx`
- `pnpm --dir web exec eslint components/Screening.tsx components/Calendar/DirectCalendar.tsx components/Calendar/index.tsx`