### PR TITLE
Add poster toggle to screening rows

### DIFF
--- a/web/components/Calendar/DirectCalendar.tsx
+++ b/web/components/Calendar/DirectCalendar.tsx
@@ -7,16 +7,23 @@ import { ScreeningRow } from '../Screening'
 export const DirectCalendar = ({
   rows,
   showCity,
+  showPoster,
 }: {
   rows: Row[]
   showCity: boolean
+  showPoster: boolean
 }) => (
   <>
     {rows.map((row, i) =>
       row.component === 'RelativeDate' ? (
         <RelativeDate key={i} {...row.props} />
       ) : (
-        <ScreeningRow key={i} {...row.props} showCity={showCity} />
+        <ScreeningRow
+          key={i}
+          {...row.props}
+          showCity={showCity}
+          showPoster={showPoster}
+        />
       ),
     )}
   </>

--- a/web/components/Calendar/index.tsx
+++ b/web/components/Calendar/index.tsx
@@ -55,11 +55,13 @@ const screeningMatchesSearch = (
 export const Calendar = ({
   screenings,
   showCity,
+  showPoster = true,
   currentCity,
   currentCinema,
 }: {
   screenings: Screening[]
   showCity: boolean
+  showPoster?: boolean
   currentCity?: string
   currentCinema?: string
 }) => {
@@ -117,7 +119,11 @@ export const Calendar = ({
           {emptyStateMessage}
         </h3>
       ) : (
-        <DirectCalendar rows={rows} showCity={showCity} />
+        <DirectCalendar
+          rows={rows}
+          showCity={showCity}
+          showPoster={showPoster}
+        />
       )}
     </div>
   )

--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -158,6 +158,7 @@ export const MoviePage = ({
             <Calendar
               screenings={screenings}
               showCity={showCity}
+              showPoster={false}
               currentCity={currentCity}
               currentCinema={currentCinema}
             />

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -129,6 +129,7 @@ export const ScreeningRow = ({
   movieSlug,
   posterUrl,
   showCity = true,
+  showPoster = true,
 }: {
   url: string
   date: DateTime
@@ -139,6 +140,7 @@ export const ScreeningRow = ({
   movieSlug?: string
   posterUrl?: string
   showCity?: boolean
+  showPoster?: boolean
 }) => {
   const movieIdClassName = movieId
     ? `movie-id-${movieId.replace(/[^a-zA-Z0-9_-]/g, '-')}`
@@ -171,7 +173,7 @@ export const ScreeningRow = ({
             {showCity ? <> | {cinema.city.name}</> : null}
           </div>
         </a>
-        {posterUrl && movieUrl ? (
+        {showPoster && posterUrl && movieUrl ? (
           <a href={movieUrl} className={posterLinkStyle}>
             <Image
               src={posterUrl}
@@ -182,7 +184,7 @@ export const ScreeningRow = ({
               className={posterStyle}
             />
           </a>
-        ) : posterUrl && tmdbUrl ? (
+        ) : showPoster && posterUrl && tmdbUrl ? (
           <a
             href={tmdbUrl}
             target="_blank"
@@ -198,7 +200,7 @@ export const ScreeningRow = ({
               className={posterStyle}
             />
           </a>
-        ) : posterUrl ? (
+        ) : showPoster && posterUrl ? (
           <Image
             src={posterUrl}
             width={48}
@@ -207,7 +209,7 @@ export const ScreeningRow = ({
             aria-hidden
             className={posterStyle}
           />
-        ) : movieId ? (
+        ) : showPoster && movieId ? (
           <div aria-hidden className={posterPlaceholderStyle} />
         ) : null}
       </div>


### PR DESCRIPTION
This adds a `showPoster` prop to screening rows, defaulting to `true`, and turns it off for movie pages so the screening list does not repeat the large movie poster shown at the top of the page.

Checks:
- `pnpm --dir web exec prettier --check components/Screening.tsx components/Calendar/DirectCalendar.tsx components/Calendar/index.tsx components/MoviePage.tsx`
- `pnpm --dir web exec eslint components/Screening.tsx components/Calendar/DirectCalendar.tsx components/Calendar/index.tsx components/MoviePage.tsx`