### PR TITLE
Add alphabetical movie overview page

### DIFF
--- a/web/app/movie/page.tsx
+++ b/web/app/movie/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+
+import { MoviesOverview } from '../../components/MoviesOverview'
+import { NavigationBar } from '../../components/NavigationBar'
+import { Layout } from '../../components/Layout'
+import { getMovies } from '../../utils/getMovies'
+import { palette } from '../../utils/theme'
+
+export const metadata: Metadata = {
+  title: 'Movies – Expat Cinema',
+  alternates: { canonical: 'https://expatcinema.com/movie' },
+}
+
+export default async function MoviesPage() {
+  const movies = await getMovies()
+
+  return (
+    <>
+      <Layout backgroundColor={palette.purple600}>
+        <Suspense>
+          <NavigationBar />
+        </Suspense>
+      </Layout>
+      <MoviesOverview movies={movies} />
+    </>
+  )
+}

--- a/web/components/Menu.tsx
+++ b/web/components/Menu.tsx
@@ -93,6 +93,12 @@ export const Menu = () => {
         About
       </Link>
       <Link
+        href="/movie"
+        className={cx(menuTextItemStyle, headerFont.className)}
+      >
+        Movies
+      </Link>
+      <Link
         href="/statistics"
         className={cx(menuTextItemStyle, headerFont.className)}
       >
@@ -119,6 +125,12 @@ export const Menu = () => {
                 className={cx(menuItemStyle, headerFont.className)}
               >
                 About
+              </Link>
+              <Link
+                href="/movie"
+                className={cx(menuItemStyle, headerFont.className)}
+              >
+                Movies
               </Link>
               <Link
                 href="/statistics"

--- a/web/components/Menu.tsx
+++ b/web/components/Menu.tsx
@@ -87,16 +87,16 @@ export const Menu = () => {
   return (
     <>
       <Link
-        href="/about"
-        className={cx(menuTextItemStyle, headerFont.className)}
-      >
-        About
-      </Link>
-      <Link
         href="/movie"
         className={cx(menuTextItemStyle, headerFont.className)}
       >
         Movies
+      </Link>
+      <Link
+        href="/about"
+        className={cx(menuTextItemStyle, headerFont.className)}
+      >
+        About
       </Link>
       <Link
         href="/statistics"
@@ -121,16 +121,16 @@ export const Menu = () => {
                 Home
               </Link>
               <Link
-                href="/about"
-                className={cx(menuItemStyle, headerFont.className)}
-              >
-                About
-              </Link>
-              <Link
                 href="/movie"
                 className={cx(menuItemStyle, headerFont.className)}
               >
                 Movies
+              </Link>
+              <Link
+                href="/about"
+                className={cx(menuItemStyle, headerFont.className)}
+              >
+                About
               </Link>
               <Link
                 href="/statistics"

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -2,13 +2,14 @@ import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
 
-import { css } from 'styled-system/css'
+import { css, cx } from 'styled-system/css'
 
 import {
   getMoviePosterUrl,
   getMovieReleaseYear,
   Movie,
 } from '../utils/getMovies'
+import { headerFont } from '../utils/theme'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
 
@@ -36,6 +37,7 @@ const sectionStyle = css({
   fontSize: '16px',
   fontWeight: '700',
   margin: '12px 0 4px',
+  color: 'var(--text-color)',
 })
 
 const rowStyle = css({
@@ -162,7 +164,9 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
         <div className={listStyle}>
           {sections.map((section) => (
             <div key={section}>
-              <h3 className={sectionStyle}>{section}</h3>
+              <h3 className={cx(sectionStyle, headerFont.className)}>
+                {section}
+              </h3>
               {moviesBySection[section].map((movie) => (
                 <MovieOverviewRow key={movie.movieId} movie={movie} />
               ))}

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -2,31 +2,21 @@ import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
 
-import { css, cx } from 'styled-system/css'
+import { css } from 'styled-system/css'
 
-import { headerFont } from '../utils/theme'
 import {
   getMoviePosterUrl,
   getMovieReleaseYear,
   Movie,
 } from '../utils/getMovies'
 import { Layout } from './Layout'
+import { PageTitle } from './PageTitle'
 
 const pageStyle = css({
   marginTop: '16px',
   marginBottom: '16px',
   display: 'grid',
   rowGap: '16px',
-})
-
-const titleStyle = css({
-  marginTop: '0',
-  marginBottom: '0',
-  fontSize: '44px',
-  lineHeight: '1.05',
-  '@media (max-width: 640px)': {
-    fontSize: '32px',
-  },
 })
 
 const introStyle = css({
@@ -132,7 +122,7 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
     <Layout>
       <div className={pageStyle}>
         <div>
-          <h1 className={cx(titleStyle, headerFont.className)}>Movies</h1>
+          <PageTitle>Movies</PageTitle>
           <p className={introStyle}>All movies sorted alphabetically.</p>
         </div>
         <div className={listStyle}>

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -1,0 +1,146 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import React from 'react'
+
+import { css, cx } from 'styled-system/css'
+
+import { headerFont } from '../utils/theme'
+import {
+  getMoviePosterUrl,
+  getMovieReleaseYear,
+  Movie,
+} from '../utils/getMovies'
+import { Layout } from './Layout'
+
+const pageStyle = css({
+  marginTop: '16px',
+  marginBottom: '16px',
+  display: 'grid',
+  rowGap: '16px',
+})
+
+const titleStyle = css({
+  marginTop: '0',
+  marginBottom: '0',
+  fontSize: '44px',
+  lineHeight: '1.05',
+  '@media (max-width: 640px)': {
+    fontSize: '32px',
+  },
+})
+
+const introStyle = css({
+  marginTop: '0',
+  marginBottom: '0',
+  fontSize: '16px',
+  lineHeight: '1.5',
+  color: 'var(--text-muted-color)',
+})
+
+const listStyle = css({
+  display: 'grid',
+  rowGap: '2px',
+})
+
+const rowStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'auto minmax(0, 1fr)',
+  gridColumnGap: '12px',
+  lineHeight: '1.5',
+  padding: '12px',
+  alignItems: 'start',
+  minHeight: '72px',
+  marginLeft: '-12px',
+  marginRight: '-12px',
+  textDecoration: 'none',
+  color: 'var(--text-color)',
+  _hover: {
+    backgroundColor: 'var(--background-highlight-color)',
+    borderRadius: '10px',
+  },
+})
+
+const posterStyle = css({
+  width: '48px',
+  height: '72px',
+  borderRadius: '4px',
+  objectFit: 'cover',
+})
+
+const posterPlaceholderStyle = css({
+  width: '48px',
+  height: '72px',
+  borderRadius: '4px',
+  backgroundColor: 'var(--background-highlight-color)',
+  border: '1px solid var(--border-color)',
+})
+
+const movieTitleStyle = css({
+  minWidth: '0',
+  paddingTop: '4px',
+  fontSize: '18px',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+})
+
+const titleYearStyle = css({
+  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
+})
+
+const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
+  const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath)
+  const year = getMovieReleaseYear(movie)
+  const content = (
+    <>
+      {posterUrl ? (
+        <Image
+          src={posterUrl}
+          width={48}
+          height={72}
+          alt=""
+          aria-hidden
+          className={posterStyle}
+        />
+      ) : (
+        <div aria-hidden className={posterPlaceholderStyle} />
+      )}
+      <div className={movieTitleStyle}>
+        {movie.title}
+        {year ? <span className={titleYearStyle}> ({year})</span> : null}
+      </div>
+    </>
+  )
+
+  if (movie.slug) {
+    return (
+      <Link href={`/movie/${movie.slug}`} className={rowStyle}>
+        {content}
+      </Link>
+    )
+  }
+
+  return <div className={rowStyle}>{content}</div>
+}
+
+export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
+  const sortedMovies = [...movies].sort((left, right) =>
+    left.title.localeCompare(right.title, undefined, { sensitivity: 'base' }),
+  )
+
+  return (
+    <Layout>
+      <div className={pageStyle}>
+        <div>
+          <h1 className={cx(titleStyle, headerFont.className)}>Movies</h1>
+          <p className={introStyle}>All movies sorted alphabetically.</p>
+        </div>
+        <div className={listStyle}>
+          {sortedMovies.map((movie) => (
+            <MovieOverviewRow key={movie.movieId} movie={movie} />
+          ))}
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -36,7 +36,7 @@ const listStyle = css({
 const sectionStyle = css({
   fontSize: '16px',
   fontWeight: '700',
-  margin: '12px 0 4px',
+  margin: '12px 0',
   color: 'var(--text-color)',
 })
 

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -32,6 +32,12 @@ const listStyle = css({
   rowGap: '2px',
 })
 
+const sectionStyle = css({
+  fontSize: '16px',
+  fontWeight: '700',
+  margin: '12px 0 4px',
+})
+
 const rowStyle = css({
   display: 'grid',
   gridTemplateColumns: 'auto minmax(0, 1fr)',
@@ -78,6 +84,12 @@ const titleYearStyle = css({
   color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
 })
 
+const getMovieSection = (title: string) => {
+  const firstLetter = title.trim().charAt(0).toUpperCase()
+
+  return firstLetter >= 'A' && firstLetter <= 'Z' ? firstLetter : '#'
+}
+
 const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
   const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath)
   const year = getMovieReleaseYear(movie)
@@ -118,6 +130,28 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
     left.title.localeCompare(right.title, undefined, { sensitivity: 'base' }),
   )
 
+  const moviesBySection = sortedMovies.reduce<Record<string, Movie[]>>(
+    (sections, movie) => {
+      const section = getMovieSection(movie.title)
+      sections[section] = sections[section] ?? []
+      sections[section].push(movie)
+      return sections
+    },
+    {},
+  )
+
+  const sections = Object.keys(moviesBySection).sort((left, right) => {
+    if (left === '#') {
+      return -1
+    }
+
+    if (right === '#') {
+      return 1
+    }
+
+    return left.localeCompare(right)
+  })
+
   return (
     <Layout>
       <div className={pageStyle}>
@@ -126,8 +160,13 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
           <p className={introStyle}>All movies sorted alphabetically.</p>
         </div>
         <div className={listStyle}>
-          {sortedMovies.map((movie) => (
-            <MovieOverviewRow key={movie.movieId} movie={movie} />
+          {sections.map((section) => (
+            <div key={section}>
+              <h3 className={sectionStyle}>{section}</h3>
+              {moviesBySection[section].map((movie) => (
+                <MovieOverviewRow key={movie.movieId} movie={movie} />
+              ))}
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
This adds a new `/movie` overview page that lists all movies alphabetically.

Each row uses the same visual language as the screening rows: hoverable full-width rows, the same title/year sizing, and the poster on the left. The overview only shows the movie title, release year, and poster. It links each movie slug to the existing `/movie/<slug>` detail page.

Also added a `Movies` entry to the site menu so the page is reachable from the main navigation.

Checks:
- `pnpm --dir web exec prettier --check components/MoviesOverview.tsx components/Menu.tsx app/movie/page.tsx`
- `pnpm --dir web exec eslint components/MoviesOverview.tsx components/Menu.tsx app/movie/page.tsx`