### PR TITLE
Add sort titles to movies

### DIFF
--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -108,7 +108,7 @@ const SORT_TITLE_ARTICLE_PATTERNS = [
   [/^(?:le|la|les|un|une)\s+/i],
   [/^l['’]/i],
   // Spanish
-  [/^los\s+/i],
+  [/^(?:el|los)\s+/i],
   // German
   [/^(?:der|das)\s+/i],
 ] as const

--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -99,6 +99,33 @@ export const slugifyMovieTitle = (title: string) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
 
+const SORT_TITLE_ARTICLE_PATTERNS = [
+  // English
+  [/^(?:a|an|the)\s+/i],
+  // Dutch
+  [/^(?:de|het|een)\s+/i],
+  // French
+  [/^(?:le|la|les|un|une)\s+/i],
+  [/^l['’]/i],
+  // Spanish
+  [/^los\s+/i],
+  // German
+  [/^(?:der|das)\s+/i],
+] as const
+
+export const getMovieSortTitle = (title: string) => {
+  const trimmedTitle = title.trim()
+
+  for (const [pattern] of SORT_TITLE_ARTICLE_PATTERNS) {
+    const match = trimmedTitle.match(pattern)
+    if (match) {
+      return trimmedTitle.slice(match[0].length).trimStart()
+    }
+  }
+
+  return trimmedTitle
+}
+
 type ScoreCandidateInput = {
   title?: string
   originalTitle?: string

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -55,6 +55,7 @@ import worm from './worm'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
 import {
   getMetadataLookupKey,
+  getMovieSortTitle,
   normalizeMovieTitleForLookup,
   slugifyMovieTitle,
 } from '../metadata/titleResolver'
@@ -346,6 +347,7 @@ export const scrapers = async () => {
               tmdbId: metadata.tmdb?.id,
               imdbId: metadata.imdbId,
               title: metadata.title,
+              sortTitle: getMovieSortTitle(metadata.title ?? ''),
               tmdb: {
                 id: metadata.tmdb?.id,
                 title: metadata.title,

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -1,4 +1,5 @@
 import {
+  getMovieSortTitle,
   getMovieId,
   getTitleSearchVariants,
   normalizeMovieTitleForLookup,
@@ -23,6 +24,24 @@ describe('titleResolver', () => {
     expect(stripTitleNoise('Hard Boiled (4K Restoration)')).toBe('Hard Boiled')
     expect(stripTitleNoise('A Family (En Subs)')).toBe('A Family')
     expect(stripTitleNoise('Hard Boiled (4K Restoration)')).toBe('Hard Boiled')
+  })
+
+  test('builds sort titles without leading articles', () => {
+    expect(getMovieSortTitle('The Matrix')).toBe('Matrix')
+    expect(getMovieSortTitle('A Family')).toBe('Family')
+    expect(getMovieSortTitle('An Education')).toBe('Education')
+    expect(getMovieSortTitle('De Tweeling')).toBe('Tweeling')
+    expect(getMovieSortTitle('Het Diner')).toBe('Diner')
+    expect(getMovieSortTitle('Een Duitse Film')).toBe('Duitse Film')
+    expect(getMovieSortTitle('Le Fabuleux Destin d’Amélie Poulain')).toBe(
+      'Fabuleux Destin d’Amélie Poulain',
+    )
+    expect(getMovieSortTitle("L'engloutie")).toBe('engloutie')
+    expect(getMovieSortTitle('Los Olvidados')).toBe('Olvidados')
+    expect(getMovieSortTitle('Der Himmel über Berlin')).toBe(
+      'Himmel über Berlin',
+    )
+    expect(getMovieSortTitle('Das Boot')).toBe('Boot')
   })
 
   test('produces multiple search variants', () => {

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -37,6 +37,9 @@ describe('titleResolver', () => {
       'Fabuleux Destin d’Amélie Poulain',
     )
     expect(getMovieSortTitle("L'engloutie")).toBe('engloutie')
+    expect(getMovieSortTitle('El laberinto del fauno')).toBe(
+      'laberinto del fauno',
+    )
     expect(getMovieSortTitle('Los Olvidados')).toBe('Olvidados')
     expect(getMovieSortTitle('Der Himmel über Berlin')).toBe(
       'Himmel über Berlin',

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -129,12 +129,16 @@ const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
 
 export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
   const sortedMovies = [...movies].sort((left, right) =>
-    left.title.localeCompare(right.title, undefined, { sensitivity: 'base' }),
+    (left.sortTitle ?? left.title).localeCompare(
+      right.sortTitle ?? right.title,
+      undefined,
+      { sensitivity: 'base' },
+    ),
   )
 
   const moviesBySection = sortedMovies.reduce<Record<string, Movie[]>>(
     (sections, movie) => {
-      const section = getMovieSection(movie.title)
+      const section = getMovieSection(movie.sortTitle ?? movie.title)
       sections[section] = sections[section] ?? []
       sections[section].push(movie)
       return sections

--- a/web/utils/getMovies.ts
+++ b/web/utils/getMovies.ts
@@ -2,6 +2,7 @@ export type MovieData = {
   movieId: string
   slug?: string
   title: string
+  sortTitle?: string
   tmdbId: number
   imdbId?: string
   tmdb?: {


### PR DESCRIPTION
This adds a `sortTitle` field to public `movies.json` by stripping leading articles from `movie.title`.

Supported article groups:
- English: `a`, `an`, `the`
- Dutch: `de`, `het`, `een`
- French: `le`, `la`, `les`, `un`, `une`, plus `l'`
- Spanish: `los`
- German: `der`, `das`

The new field is consumed by the movie overview page for alphabetical sorting and section grouping.

Checks:
- `pnpm --dir cloud exec jest test/titleResolver.test.ts --runInBand`
- `pnpm --dir web exec prettier --check components/MoviesOverview.tsx utils/getMovies.ts`
- `pnpm --dir web exec eslint components/MoviesOverview.tsx utils/getMovies.ts`