### PR TITLE
[codex] add hidden unmatched movies page

### DIFF
--- a/web/app/movie/unmatched/page.tsx
+++ b/web/app/movie/unmatched/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
-import { NavigationBar } from '../../components/NavigationBar'
-import { Layout } from '../../components/Layout'
-import { UnmatchedMoviesOverview } from '../../components/UnmatchedMoviesOverview'
-import { getScreenings } from '../../utils/getScreenings'
-import { palette } from '../../utils/theme'
+import { NavigationBar } from '../../../components/NavigationBar'
+import { Layout } from '../../../components/Layout'
+import { UnmatchedMoviesOverview } from '../../../components/UnmatchedMoviesOverview'
+import { getScreenings } from '../../../utils/getScreenings'
+import { palette } from '../../../utils/theme'
 
 export const metadata: Metadata = {
   title: 'Unmatched movies – Expat Cinema',

--- a/web/app/movie/unmatched/page.tsx
+++ b/web/app/movie/unmatched/page.tsx
@@ -9,7 +9,7 @@ import { palette } from '../../utils/theme'
 
 export const metadata: Metadata = {
   title: 'Unmatched movies – Expat Cinema',
-  alternates: { canonical: 'https://expatcinema.com/unmatched_movie' },
+  alternates: { canonical: 'https://expatcinema.com/movie/unmatched' },
   robots: {
     index: false,
     follow: false,

--- a/web/app/unmatched_movies/page.tsx
+++ b/web/app/unmatched_movies/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+
+import { NavigationBar } from '../../components/NavigationBar'
+import { Layout } from '../../components/Layout'
+import { UnmatchedMoviesOverview } from '../../components/UnmatchedMoviesOverview'
+import { getScreenings } from '../../utils/getScreenings'
+import { palette } from '../../utils/theme'
+
+export const metadata: Metadata = {
+  title: 'Unmatched movies – Expat Cinema',
+  alternates: { canonical: 'https://expatcinema.com/unmatched_movies' },
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
+
+export default async function UnmatchedMoviesPage() {
+  const screenings = await getScreenings()
+
+  return (
+    <>
+      <Layout backgroundColor={palette.purple600}>
+        <Suspense>
+          <NavigationBar />
+        </Suspense>
+      </Layout>
+      <UnmatchedMoviesOverview screenings={screenings} />
+    </>
+  )
+}

--- a/web/app/unmatched_movies/page.tsx
+++ b/web/app/unmatched_movies/page.tsx
@@ -9,7 +9,7 @@ import { palette } from '../../utils/theme'
 
 export const metadata: Metadata = {
   title: 'Unmatched movies – Expat Cinema',
-  alternates: { canonical: 'https://expatcinema.com/unmatched_movies' },
+  alternates: { canonical: 'https://expatcinema.com/unmatched_movie' },
   robots: {
     index: false,
     follow: false,

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -12,6 +12,7 @@ import {
 import { headerFont } from '../utils/theme'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
+import { PageSection } from './PageSection'
 
 const pageStyle = css({
   marginTop: '16px',
@@ -26,6 +27,15 @@ const introStyle = css({
   fontSize: '16px',
   lineHeight: '1.5',
   color: 'var(--text-muted-color)',
+})
+
+const footerStyle = css({
+  fontSize: '18px',
+  lineHeight: '1.4',
+})
+
+const textLinkStyle = css({
+  color: 'var(--secondary-color)',
 })
 
 const listStyle = css({
@@ -176,6 +186,16 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
               ))}
             </div>
           ))}
+        </div>
+        <div className={footerStyle}>
+          <PageSection>Unmatched movies</PageSection>
+          <p>
+            View the{' '}
+            <Link href="/movie/unmatched" className={textLinkStyle}>
+              unmatched movies
+            </Link>{' '}
+            list.
+          </p>
         </div>
       </div>
     </Layout>

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -173,7 +173,10 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
       <div className={pageStyle}>
         <div>
           <PageTitle>Movies</PageTitle>
-          <p className={introStyle}>All movies sorted alphabetically.</p>
+          <p className={introStyle}>
+            All movies for which there are screenings with English subtitles
+            scheduled.
+          </p>
         </div>
         <div className={listStyle}>
           {sections.map((section) => (

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from 'next/link'
 
 import { css, cx } from 'styled-system/css'
 
@@ -88,7 +89,10 @@ const getUnmatchedMovieKey = (screening: Screening) =>
   `${screening.title}__${screening.year ?? ''}`
 
 const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
-  <div className={rowStyle}>
+  <Link
+    href={`/?search=${encodeURIComponent(screening.title)}`}
+    className={rowStyle}
+  >
     <div
       aria-hidden
       className={cx(
@@ -102,7 +106,7 @@ const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
         <span className={titleYearStyle}> ({screening.year})</span>
       ) : null}
     </div>
-  </div>
+  </Link>
 )
 
 export const UnmatchedMoviesOverview = ({

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -1,0 +1,175 @@
+import React from 'react'
+
+import { css, cx } from 'styled-system/css'
+
+import { Screening } from '../utils/getScreenings'
+import { headerFont } from '../utils/theme'
+import { Layout } from './Layout'
+import { PageTitle } from './PageTitle'
+
+const pageStyle = css({
+  marginTop: '16px',
+  marginBottom: '16px',
+  display: 'grid',
+  rowGap: '16px',
+})
+
+const introStyle = css({
+  marginTop: '0',
+  marginBottom: '0',
+  fontSize: '16px',
+  lineHeight: '1.5',
+  color: 'var(--text-muted-color)',
+})
+
+const listStyle = css({
+  display: 'grid',
+  rowGap: '2px',
+})
+
+const sectionStyle = css({
+  fontSize: '16px',
+  fontWeight: '700',
+  margin: '12px 0',
+  color: 'var(--text-color)',
+})
+
+const rowStyle = css({
+  display: 'grid',
+  gridTemplateColumns: 'auto minmax(0, 1fr)',
+  gridColumnGap: '12px',
+  lineHeight: '1.5',
+  padding: '12px',
+  alignItems: 'start',
+  minHeight: '72px',
+  marginLeft: '-12px',
+  marginRight: '-12px',
+  textDecoration: 'none',
+  color: 'var(--text-color)',
+  _hover: {
+    backgroundColor: 'var(--background-highlight-color)',
+    borderRadius: '10px',
+  },
+})
+
+const posterPlaceholderStyle = css({
+  width: '48px',
+  height: '72px',
+  borderRadius: '4px',
+  backgroundColor: 'var(--background-highlight-color)',
+  border: '1px solid var(--border-color)',
+})
+
+const movieTitleStyle = css({
+  minWidth: '0',
+  paddingTop: '4px',
+  fontSize: '18px',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+})
+
+const titleYearStyle = css({
+  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
+})
+
+const getMovieSection = (title: string) => {
+  const firstLetter = title.trim().charAt(0).toUpperCase()
+
+  return firstLetter >= 'A' && firstLetter <= 'Z' ? firstLetter : '#'
+}
+
+const getUnmatchedMovieKey = (screening: Screening) =>
+  `${screening.title}__${screening.year ?? ''}`
+
+const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
+  <div className={rowStyle}>
+    <div aria-hidden className={posterPlaceholderStyle} />
+    <div className={movieTitleStyle}>
+      {screening.title}
+      {screening.year ? (
+        <span className={titleYearStyle}> ({screening.year})</span>
+      ) : null}
+    </div>
+  </div>
+)
+
+export const UnmatchedMoviesOverview = ({
+  screenings,
+}: {
+  screenings: Screening[]
+}) => {
+  const unmatchedMovies = screenings.filter((screening) => !screening.movieId)
+
+  const uniqueUnmatchedMovies = Array.from(
+    unmatchedMovies
+      .reduce<Map<string, Screening>>((movies, screening) => {
+        const key = getUnmatchedMovieKey(screening)
+        if (!movies.has(key)) {
+          movies.set(key, screening)
+        }
+
+        return movies
+      }, new Map())
+      .values(),
+  ).sort((left, right) => {
+    const titleComparison = left.title.localeCompare(right.title, undefined, {
+      sensitivity: 'base',
+    })
+
+    if (titleComparison !== 0) {
+      return titleComparison
+    }
+
+    return (right.year ?? 0) - (left.year ?? 0)
+  })
+
+  const moviesBySection = uniqueUnmatchedMovies.reduce<
+    Record<string, Screening[]>
+  >((sections, screening) => {
+    const section = getMovieSection(screening.title)
+    sections[section] = sections[section] ?? []
+    sections[section].push(screening)
+    return sections
+  }, {})
+
+  const sections = Object.keys(moviesBySection).sort((left, right) => {
+    if (left === '#') {
+      return -1
+    }
+
+    if (right === '#') {
+      return 1
+    }
+
+    return left.localeCompare(right)
+  })
+
+  return (
+    <Layout>
+      <div className={pageStyle}>
+        <div>
+          <PageTitle>Unmatched movies</PageTitle>
+          <p className={introStyle}>
+            All movies without a movieId, sorted alphabetically.
+          </p>
+        </div>
+        <div className={listStyle}>
+          {sections.map((section) => (
+            <div key={section}>
+              <h3 className={cx(sectionStyle, headerFont.className)}>
+                {section}
+              </h3>
+              {moviesBySection[section].map((screening) => (
+                <UnmatchedMovieRow
+                  key={getUnmatchedMovieKey(screening)}
+                  screening={screening}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </Layout>
+  )
+}

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -166,7 +166,8 @@ export const UnmatchedMoviesOverview = ({
         <div>
           <PageTitle>Unmatched movies</PageTitle>
           <p className={introStyle}>
-            All movies without a movieId, sorted alphabetically.
+            All movies that couldn't be matched to a known movie in The Movie
+            Database.
           </p>
         </div>
         <div className={listStyle}>

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { css, cx } from 'styled-system/css'
 
 import { Screening } from '../utils/getScreenings'
-import { headerFont } from '../utils/theme'
+import { headerFont, palette } from '../utils/theme'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
 
@@ -46,9 +46,13 @@ const rowStyle = css({
   marginRight: '-12px',
   textDecoration: 'none',
   color: 'var(--text-color)',
-  _hover: {
+  '&:hover': {
     backgroundColor: 'var(--background-highlight-color)',
     borderRadius: '10px',
+  },
+  '&:hover .unmatched-movie-poster-placeholder': {
+    backgroundColor: palette.purple500,
+    borderColor: palette.purple500,
   },
 })
 
@@ -58,6 +62,7 @@ const posterPlaceholderStyle = css({
   borderRadius: '4px',
   backgroundColor: 'var(--background-highlight-color)',
   border: '1px solid var(--border-color)',
+  transition: 'background-color 120ms ease, border-color 120ms ease',
 })
 
 const movieTitleStyle = css({
@@ -84,7 +89,13 @@ const getUnmatchedMovieKey = (screening: Screening) =>
 
 const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
   <div className={rowStyle}>
-    <div aria-hidden className={posterPlaceholderStyle} />
+    <div
+      aria-hidden
+      className={cx(
+        posterPlaceholderStyle,
+        'unmatched-movie-poster-placeholder',
+      )}
+    />
     <div className={movieTitleStyle}>
       {screening.title}
       {screening.year ? (


### PR DESCRIPTION
## What changed
- Added a hidden `/unmatched_movies` page that lists screenings without a `movieId`.
- Reused the movie-overview layout: alphabetical sections, poster placeholder on the left, title, and year only.
- Added a hover refinement so the poster placeholder turns the darker purple theme color on hover.
- Kept the route out of the main menu and marked it `noindex`.

## Why
- This gives a quick overview of unresolved titles without mixing them into the main `/movie` page.

## Validation
- `pnpm --dir web exec prettier --check components/UnmatchedMoviesOverview.tsx`
- `pnpm --dir web exec eslint components/UnmatchedMoviesOverview.tsx`
