### PR TITLE
Use TMDB popularity to break ambiguous matches

### DIFF
--- a/cloud/metadata/searchMetadata.ts
+++ b/cloud/metadata/searchMetadata.ts
@@ -14,6 +14,7 @@ import {
   getTitleSearchVariants,
   normalizeMovieTitleForLookup,
   scoreCandidateWithYearHints,
+  selectCandidateWithPopularityTieBreak,
 } from './titleResolver'
 import { Metadata, TmdbMovie } from './types'
 
@@ -169,7 +170,9 @@ const searchMetadata = async (
     }))
     .sort((left, right) => right.confidence - left.confidence)
 
-  const bestCandidate = scoredCandidates[0]
+  const bestCandidateSelection =
+    selectCandidateWithPopularityTieBreak(scoredCandidates)
+  const bestCandidate = bestCandidateSelection?.winner
   const secondCandidate = scoredCandidates[1]
 
   logger.info('searchMetadata scored candidates', {
@@ -183,6 +186,7 @@ const searchMetadata = async (
       title: entry.candidate.title,
       originalTitle: entry.candidate.originalTitle,
       releaseDate: entry.candidate.releaseDate,
+      popularity: entry.candidate.popularity,
       confidence: entry.confidence,
     })),
   })
@@ -190,7 +194,8 @@ const searchMetadata = async (
   if (
     bestCandidate &&
     bestCandidate.confidence >= 0.9 &&
-    (!secondCandidate ||
+    (bestCandidateSelection?.hasPopularityTieBreak ||
+      !secondCandidate ||
       bestCandidate.confidence - secondCandidate.confidence >= 0.05)
   ) {
     const tmdbMovie = await getTmdbMovie(bestCandidate.candidate.id)
@@ -211,6 +216,7 @@ const searchMetadata = async (
         title: entry.candidate.title,
         originalTitle: entry.candidate.originalTitle,
         releaseDate: entry.candidate.releaseDate,
+        popularity: entry.candidate.popularity,
         confidence: entry.confidence,
       })),
     })
@@ -230,6 +236,7 @@ const searchMetadata = async (
         title: entry.candidate.title,
         originalTitle: entry.candidate.originalTitle,
         releaseDate: entry.candidate.releaseDate,
+        popularity: entry.candidate.popularity,
         confidence: entry.confidence,
       })),
     },

--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -133,10 +133,12 @@ type ScoreCandidateInput = {
   alternativeTitles?: string[]
 }
 
-const getYearScore = (
-  releaseYear: number | undefined,
-  yearHints: number[],
-) => {
+export type ScoredCandidate<T> = {
+  candidate: T
+  confidence: number
+}
+
+const getYearScore = (releaseYear: number | undefined, yearHints: number[]) => {
   if (!releaseYear || yearHints.length === 0) {
     return 0.5
   }
@@ -200,4 +202,37 @@ export const scoreCandidate = (
     candidate,
     yearHintOverride !== undefined ? [yearHintOverride] : [],
   )
+}
+
+export const selectCandidateWithPopularityTieBreak = <
+  T extends { popularity?: number },
+>(
+  candidates: Array<ScoredCandidate<T>>,
+) => {
+  const byConfidence = [...candidates].sort(
+    (left, right) => right.confidence - left.confidence,
+  )
+  const bestConfidence = byConfidence[0]?.confidence
+
+  if (bestConfidence === undefined) {
+    return undefined
+  }
+
+  const confidenceBand = byConfidence.filter(
+    (candidate) => bestConfidence - candidate.confidence < 0.05,
+  )
+  const byPopularity = [...confidenceBand].sort(
+    (left, right) =>
+      (right.candidate.popularity ?? -1) - (left.candidate.popularity ?? -1),
+  )
+
+  const winner = byPopularity[0] ?? byConfidence[0]
+  const topPopularity = byPopularity[0]?.candidate.popularity ?? -1
+  const secondPopularity = byPopularity[1]?.candidate.popularity ?? -1
+
+  return {
+    winner,
+    hasPopularityTieBreak:
+      confidenceBand.length > 1 && topPopularity > secondPopularity,
+  }
 }

--- a/cloud/metadata/types.ts
+++ b/cloud/metadata/types.ts
@@ -53,6 +53,7 @@ export type MetadataMatch = {
     title?: string
     originalTitle?: string
     releaseDate?: string
+    popularity?: number
     confidence: number
   }>
 }

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeMovieTitleForLookup,
   scoreCandidate,
   scoreCandidateWithYearHints,
+  selectCandidateWithPopularityTieBreak,
   stripTitleNoise,
 } from '../metadata/titleResolver'
 
@@ -130,5 +131,21 @@ describe('titleResolver', () => {
 
     expect(siblingYearScore).toBeGreaterThan(screeningYearScore)
     expect(siblingYearScore).toBeGreaterThan(0.9)
+  })
+
+  test('uses popularity to break ties between equally strong candidates', () => {
+    const selected = selectCandidateWithPopularityTieBreak([
+      {
+        candidate: { id: 399031, popularity: 1.8699 },
+        confidence: 1,
+      },
+      {
+        candidate: { id: 399219, popularity: 0.0306 },
+        confidence: 1,
+      },
+    ])
+
+    expect(selected?.winner?.candidate.id).toBe(399031)
+    expect(selected?.hasPopularityTieBreak).toBe(true)
   })
 })


### PR DESCRIPTION
When TMDB search candidates land in the ambiguous zone, prefer the more popular movie instead of leaving the match unresolved.

This keeps the existing confidence scoring and only uses popularity as a tie-break for near-equal candidates.

Validation:
- `pnpm --dir cloud exec prettier --check metadata/titleResolver.ts metadata/searchMetadata.ts metadata/types.ts test/titleResolver.test.ts`
- `pnpm exec jest test/titleResolver.test.ts --runInBand` (cloud)
- file-scoped TypeScript check for the touched cloud files