### PR TITLE
Avoid scrolling when navigating movie location filters

### DIFF
--- a/web/components/MovieLocationFilters.tsx
+++ b/web/components/MovieLocationFilters.tsx
@@ -115,7 +115,9 @@ export const MovieLocationFilters = ({
   const cinemaSelectValue = currentCinema ?? ''
 
   const navigateTo = (city?: string, cinema?: string) => {
-    router.push(getMoviePagePath(movieSlug, city ?? null, cinema ?? null))
+    router.push(getMoviePagePath(movieSlug, city ?? null, cinema ?? null), {
+      scroll: false,
+    })
   }
 
   return (


### PR DESCRIPTION
### Motivation
- Prevent the page from jumping/scrolling when a user changes the city or cinema filter in the movie page navigation.

### Description
- Pass `{ scroll: false }` as the second argument to `router.push` in `MovieLocationFilters` so navigation between filter states preserves the current scroll position.

### Testing
- Ran the frontend build and test commands (`yarn build` and `yarn test`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e333766e50832e96c312866d611ccc)