### PR TITLE
Centralize shared web list styles

### DIFF
--- a/web/components/Calendar/index.tsx
+++ b/web/components/Calendar/index.tsx
@@ -4,9 +4,8 @@ import { DateTime } from 'luxon'
 import dynamic from 'next/dynamic'
 import React from 'react'
 
-import { css, cx } from 'styled-system/css'
+import { css } from 'styled-system/css'
 
-import { headerFont } from '../../utils/theme'
 import { getCinema } from '../../utils/getCinema'
 import { getCity } from '../../utils/getCity'
 import { Screening } from '../../utils/getScreenings'
@@ -18,6 +17,7 @@ import { getMoviePagePath } from '../../utils/getMoviePagePath'
 import { useSearch } from '../../utils/hooks'
 import { DirectCalendar } from './DirectCalendar'
 import { removeDiacritics } from '../../utils/removeDiacritics'
+import { listSectionHeadingStyle } from '../listStyles'
 
 export type Row =
   | { component: 'RelativeDate'; props: { children: string } }
@@ -29,12 +29,6 @@ export type Row =
 const containerStyle = css({
   marginTop: '24px',
   marginBottom: '24px',
-})
-
-const emptyStateStyle = css({
-  fontSize: '16px',
-  fontWeight: '700',
-  margin: '12px 0',
 })
 
 const screeningMatchesSearch = (
@@ -124,9 +118,7 @@ export const Calendar = ({
   return (
     <div className={containerStyle}>
       {rows.length === 0 ? (
-        <h3 className={cx(emptyStateStyle, headerFont.className)}>
-          {emptyStateMessage}
-        </h3>
+        <h3 className={listSectionHeadingStyle}>{emptyStateMessage}</h3>
       ) : (
         <DirectCalendar
           rows={rows}

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -9,10 +9,18 @@ import {
   getMovieReleaseYear,
   Movie,
 } from '../utils/getMovies'
-import { headerFont } from '../utils/theme'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
 import { PageSection } from './PageSection'
+import {
+  listContainerStyle,
+  listSectionHeadingStyle,
+  listPosterPlaceholderStyle,
+  listPosterStyle,
+  listRowBaseStyle,
+  listTitleStyle,
+  listYearStyle,
+} from './listStyles'
 
 const pageStyle = css({
   marginTop: '16px',
@@ -38,63 +46,13 @@ const textLinkStyle = css({
   color: 'var(--secondary-color)',
 })
 
-const listStyle = css({
-  display: 'grid',
-  rowGap: '2px',
-})
-
-const sectionStyle = css({
-  fontSize: '16px',
-  fontWeight: '700',
-  margin: '12px 0',
-  color: 'var(--text-color)',
-})
-
 const rowStyle = css({
   display: 'grid',
   gridTemplateColumns: 'auto minmax(0, 1fr)',
   gridColumnGap: '12px',
-  lineHeight: '1.5',
-  padding: '12px',
-  alignItems: 'start',
-  minHeight: '72px',
-  marginLeft: '-12px',
-  marginRight: '-12px',
-  textDecoration: 'none',
-  color: 'var(--text-color)',
-  _hover: {
-    backgroundColor: 'var(--background-highlight-color)',
-    borderRadius: '10px',
-  },
 })
 
-const posterStyle = css({
-  width: '48px',
-  height: '72px',
-  borderRadius: '4px',
-  objectFit: 'cover',
-})
-
-const posterPlaceholderStyle = css({
-  width: '48px',
-  height: '72px',
-  borderRadius: '4px',
-  backgroundColor: 'var(--background-highlight-color)',
-  border: '1px solid var(--border-color)',
-})
-
-const movieTitleStyle = css({
-  minWidth: '0',
-  paddingTop: '4px',
-  fontSize: '18px',
-  whiteSpace: 'nowrap',
-  textOverflow: 'ellipsis',
-  overflow: 'hidden',
-})
-
-const titleYearStyle = css({
-  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
-})
+const rowClassName = cx(listRowBaseStyle, rowStyle)
 
 const getMovieSection = (title: string) => {
   const firstLetter = title.trim().charAt(0).toUpperCase()
@@ -114,27 +72,27 @@ const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
           height={72}
           alt=""
           aria-hidden
-          className={posterStyle}
+          className={listPosterStyle}
         />
       ) : (
-        <div aria-hidden className={posterPlaceholderStyle} />
+        <div aria-hidden className={listPosterPlaceholderStyle} />
       )}
-      <div className={movieTitleStyle}>
+      <div className={listTitleStyle}>
         {movie.title}
-        {year ? <span className={titleYearStyle}> ({year})</span> : null}
+        {year ? <span className={listYearStyle}> ({year})</span> : null}
       </div>
     </>
   )
 
   if (movie.slug) {
     return (
-      <Link href={`/movie/${movie.slug}`} className={rowStyle}>
+      <Link href={`/movie/${movie.slug}`} className={rowClassName}>
         {content}
       </Link>
     )
   }
 
-  return <div className={rowStyle}>{content}</div>
+  return <div className={rowClassName}>{content}</div>
 }
 
 export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
@@ -178,12 +136,10 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
             scheduled.
           </p>
         </div>
-        <div className={listStyle}>
+        <div className={listContainerStyle}>
           {sections.map((section) => (
             <div key={section}>
-              <h3 className={cx(sectionStyle, headerFont.className)}>
-                {section}
-              </h3>
+              <h3 className={listSectionHeadingStyle}>{section}</h3>
               {moviesBySection[section].map((movie) => (
                 <MovieOverviewRow key={movie.movieId} movie={movie} />
               ))}

--- a/web/components/PageHeading.tsx
+++ b/web/components/PageHeading.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import { css, cx } from 'styled-system/css'
+
+import { headerFont } from '../utils/theme'
+
+const headingStyle = css({
+  marginTop: '16px',
+  marginBottom: '0',
+  lineHeight: '1.8',
+})
+
+type PageHeadingProps = React.HTMLAttributes<HTMLHeadingElement> & {
+  as: 'h1' | 'h2'
+}
+
+export const PageHeading = ({ as: Tag, ...props }: PageHeadingProps) => (
+  <Tag className={cx(headingStyle, headerFont.className)} {...props} />
+)

--- a/web/components/PageSection.tsx
+++ b/web/components/PageSection.tsx
@@ -1,15 +1,7 @@
 import React from 'react'
 
-import { css, cx } from 'styled-system/css'
-
-import { headerFont } from '../utils/theme'
-
-const titleStyle = css({
-  marginTop: '16px',
-  marginBottom: '0',
-  lineHeight: '1.8',
-})
+import { PageHeading } from './PageHeading'
 
 export const PageSection = (
   props: React.HTMLAttributes<HTMLHeadingElement>,
-) => <h2 className={cx(titleStyle, headerFont.className)} {...props} />
+) => <PageHeading as="h2" {...props} />

--- a/web/components/PageTitle.tsx
+++ b/web/components/PageTitle.tsx
@@ -1,15 +1,7 @@
 import React from 'react'
 
-import { css, cx } from 'styled-system/css'
-
-import { headerFont } from '../utils/theme'
-
-const titleStyle = css({
-  marginTop: '16px',
-  marginBottom: '0',
-  lineHeight: '1.8',
-})
+import { PageHeading } from './PageHeading'
 
 export const PageTitle = (props: React.HTMLAttributes<HTMLHeadingElement>) => (
-  <h1 className={cx(titleStyle, headerFont.className)} {...props} />
+  <PageHeading as="h1" {...props} />
 )

--- a/web/components/RelativeDate.tsx
+++ b/web/components/RelativeDate.tsx
@@ -2,16 +2,8 @@
 
 import { DateTime } from 'luxon'
 
-import { css, cx } from 'styled-system/css'
-
 import { getToday } from '../utils/getToday'
-import { headerFont } from '../utils/theme'
-
-const dateStyle = css({
-  fontSize: '16px',
-  fontWeight: '700',
-  margin: '12px 0',
-})
+import { listSectionHeadingStyle } from './listStyles'
 
 export const RelativeDate = ({ children }: { children: string }) => {
   const date = DateTime.fromISO(children)
@@ -26,5 +18,5 @@ export const RelativeDate = ({ children }: { children: string }) => {
     relativeDate = 'Tomorrow'
   }
 
-  return <h3 className={cx(dateStyle, headerFont.className)}>{relativeDate}</h3>
+  return <h3 className={listSectionHeadingStyle}>{relativeDate}</h3>
 }

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -2,33 +2,33 @@ import { DateTime } from 'luxon'
 import Image from 'next/image'
 import React from 'react'
 
-import { css } from 'styled-system/css'
+import { css, cx } from 'styled-system/css'
 
 import { Cinema } from '../utils/getScreenings'
 import { getMoviePagePath } from '../utils/getMoviePagePath'
 import { Time } from './Time'
+import {
+  listPosterPlaceholderStyle,
+  listPosterStyle,
+  listRowBaseStyle,
+  listTitleStyle,
+  listYearStyle,
+} from './listStyles'
 
 const aStyle = css({
   textDecoration: 'none',
   color: 'var(--text-color)',
 })
 
-const containerStyle = css({
-  display: 'grid',
-  gridTemplateColumns: '[time] 60px [rest] minmax(0, 1fr) [poster] auto',
-  gridTemplateRows: 'auto auto',
-  gridColumnGap: '12px',
-  lineHeight: '1.5',
-  padding: '12px',
-  alignItems: 'start',
-  minHeight: '72px',
-  marginLeft: '-12px',
-  marginRight: '-12px',
-  _hover: {
-    backgroundColor: 'var(--background-highlight-color)',
-    borderRadius: '10px',
-  },
-})
+const containerStyle = cx(
+  listRowBaseStyle,
+  css({
+    display: 'grid',
+    gridTemplateColumns: '[time] 60px [rest] minmax(0, 1fr) [poster] auto',
+    gridTemplateRows: 'auto auto',
+    gridColumnGap: '12px',
+  }),
+)
 
 const timeStyle = css({
   gridColumnStart: 'time',
@@ -41,21 +41,6 @@ const contentStyle = css({
   display: 'contents',
 })
 
-const titleStyle = css({
-  gridColumnStart: 'rest',
-  gridRowStart: '1',
-  minWidth: '0',
-  paddingTop: '4px',
-  fontSize: '18px',
-  whiteSpace: 'nowrap',
-  textOverflow: 'ellipsis',
-  overflow: 'hidden',
-})
-
-const titleYearStyle = css({
-  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
-})
-
 const cinemaInfoStyle = css({
   gridColumnStart: 'rest',
   gridRowStart: '2',
@@ -64,21 +49,6 @@ const cinemaInfoStyle = css({
   color: 'var(--text-muted-color)',
   display: 'flex',
   alignItems: 'center',
-})
-
-const posterStyle = css({
-  width: '48px',
-  height: '72px',
-  borderRadius: '4px',
-  objectFit: 'cover',
-})
-
-const posterPlaceholderStyle = css({
-  width: '48px',
-  height: '72px',
-  borderRadius: '4px',
-  backgroundColor: 'var(--background-highlight-color)',
-  border: '1px solid var(--border-color)',
 })
 
 const posterLinkStyle = css({
@@ -167,9 +137,9 @@ export const ScreeningRow = ({
           href={url}
           className={`${aStyle} ${screeningLinkStyle} ${contentStyle}`}
         >
-          <div className={titleStyle}>
+          <div className={listTitleStyle}>
             {title}
-            {year ? <span className={titleYearStyle}> ({year})</span> : null}
+            {year ? <span className={listYearStyle}> ({year})</span> : null}
           </div>
           <div className={cinemaInfoStyle}>
             <CinemaIcon cinema={cinema} />
@@ -185,7 +155,7 @@ export const ScreeningRow = ({
               height={72}
               alt=""
               aria-hidden
-              className={posterStyle}
+              className={listPosterStyle}
             />
           </a>
         ) : showPoster && posterUrl && tmdbUrl ? (
@@ -201,7 +171,7 @@ export const ScreeningRow = ({
               height={72}
               alt=""
               aria-hidden
-              className={posterStyle}
+              className={listPosterStyle}
             />
           </a>
         ) : showPoster && posterUrl ? (
@@ -211,10 +181,10 @@ export const ScreeningRow = ({
             height={72}
             alt=""
             aria-hidden
-            className={posterStyle}
+            className={listPosterStyle}
           />
         ) : showPoster && movieId ? (
-          <div aria-hidden className={posterPlaceholderStyle} />
+          <div aria-hidden className={listPosterPlaceholderStyle} />
         ) : null}
       </div>
     </div>

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -4,9 +4,17 @@ import Link from 'next/link'
 import { css, cx } from 'styled-system/css'
 
 import { Screening } from '../utils/getScreenings'
-import { headerFont, palette } from '../utils/theme'
+import { palette } from '../utils/theme'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
+import {
+  listContainerStyle,
+  listSectionHeadingStyle,
+  listPosterPlaceholderStyle,
+  listRowBaseStyle,
+  listTitleStyle,
+  listYearStyle,
+} from './listStyles'
 
 const pageStyle = css({
   marginTop: '16px',
@@ -23,61 +31,21 @@ const introStyle = css({
   color: 'var(--text-muted-color)',
 })
 
-const listStyle = css({
-  display: 'grid',
-  rowGap: '2px',
-})
-
-const sectionStyle = css({
-  fontSize: '16px',
-  fontWeight: '700',
-  margin: '12px 0',
-  color: 'var(--text-color)',
-})
-
-const rowStyle = css({
-  display: 'grid',
-  gridTemplateColumns: 'auto minmax(0, 1fr)',
-  gridColumnGap: '12px',
-  lineHeight: '1.5',
-  padding: '12px',
-  alignItems: 'start',
-  minHeight: '72px',
-  marginLeft: '-12px',
-  marginRight: '-12px',
-  textDecoration: 'none',
-  color: 'var(--text-color)',
-  '&:hover': {
-    backgroundColor: 'var(--background-highlight-color)',
-    borderRadius: '10px',
-  },
-  '&:hover .unmatched-movie-poster-placeholder': {
-    backgroundColor: palette.purple500,
-    borderColor: palette.purple500,
-  },
-})
-
-const posterPlaceholderStyle = css({
-  width: '48px',
-  height: '72px',
-  borderRadius: '4px',
-  backgroundColor: 'var(--background-highlight-color)',
-  border: '1px solid var(--border-color)',
-  transition: 'background-color 120ms ease, border-color 120ms ease',
-})
-
-const movieTitleStyle = css({
-  minWidth: '0',
-  paddingTop: '4px',
-  fontSize: '18px',
-  whiteSpace: 'nowrap',
-  textOverflow: 'ellipsis',
-  overflow: 'hidden',
-})
-
-const titleYearStyle = css({
-  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
-})
+const rowStyle = cx(
+  listRowBaseStyle,
+  css({
+    display: 'grid',
+    gridTemplateColumns: 'auto minmax(0, 1fr)',
+    '&:hover': {
+      backgroundColor: 'var(--background-highlight-color)',
+      borderRadius: '10px',
+    },
+    '&:hover .unmatched-movie-poster-placeholder': {
+      backgroundColor: palette.purple500,
+      borderColor: palette.purple500,
+    },
+  }),
+)
 
 const getMovieSection = (title: string) => {
   const firstLetter = title.trim().charAt(0).toUpperCase()
@@ -96,14 +64,14 @@ const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
     <div
       aria-hidden
       className={cx(
-        posterPlaceholderStyle,
+        listPosterPlaceholderStyle,
         'unmatched-movie-poster-placeholder',
       )}
     />
-    <div className={movieTitleStyle}>
+    <div className={listTitleStyle}>
       {screening.title}
       {screening.year ? (
-        <span className={titleYearStyle}> ({screening.year})</span>
+        <span className={listYearStyle}> ({screening.year})</span>
       ) : null}
     </div>
   </Link>
@@ -170,12 +138,10 @@ export const UnmatchedMoviesOverview = ({
             Database.
           </p>
         </div>
-        <div className={listStyle}>
+        <div className={listContainerStyle}>
           {sections.map((section) => (
             <div key={section}>
-              <h3 className={cx(sectionStyle, headerFont.className)}>
-                {section}
-              </h3>
+              <h3 className={listSectionHeadingStyle}>{section}</h3>
               {moviesBySection[section].map((screening) => (
                 <UnmatchedMovieRow
                   key={getUnmatchedMovieKey(screening)}

--- a/web/components/listStyles.ts
+++ b/web/components/listStyles.ts
@@ -1,0 +1,60 @@
+import { css } from 'styled-system/css'
+
+import { headerFont } from '../utils/theme'
+
+export const listContainerStyle = css({
+  display: 'grid',
+  rowGap: '2px',
+})
+
+export const listSectionTitleStyle = css({
+  fontSize: '16px',
+  fontWeight: '700',
+  margin: '12px 0',
+  color: 'var(--text-color)',
+})
+
+export const listSectionHeadingStyle = `${listSectionTitleStyle} ${headerFont.className}`
+
+export const listRowBaseStyle = css({
+  lineHeight: '1.5',
+  padding: '12px',
+  alignItems: 'start',
+  minHeight: '72px',
+  marginLeft: '-12px',
+  marginRight: '-12px',
+  textDecoration: 'none',
+  color: 'var(--text-color)',
+  _hover: {
+    backgroundColor: 'var(--background-highlight-color)',
+    borderRadius: '10px',
+  },
+})
+
+export const listPosterStyle = css({
+  width: '48px',
+  height: '72px',
+  borderRadius: '4px',
+  objectFit: 'cover',
+})
+
+export const listPosterPlaceholderStyle = css({
+  width: '48px',
+  height: '72px',
+  borderRadius: '4px',
+  backgroundColor: 'var(--background-highlight-color)',
+  border: '1px solid var(--border-color)',
+})
+
+export const listTitleStyle = css({
+  minWidth: '0',
+  paddingTop: '4px',
+  fontSize: '18px',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+})
+
+export const listYearStyle = css({
+  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
+})

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -12,6 +12,7 @@ body {
   --background-color: #fff5f0;
   --background-inverse-color: #310d23;
   --background-highlight-color: #ffe5e0;
+  --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
 
   --primary-color: #ffafb0;
   --secondary-color: #8c3547;
@@ -21,6 +22,7 @@ body {
     --text-muted-color: rgba(255, 255, 255, 0.7);
     --background-color: #310d23;
     --background-highlight-color: #411d33;
+    --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
   }
 
   background-color: var(--background-color);


### PR DESCRIPTION
This PR addresses the UX/code review cleanup items for `web/`:

- defines `--border-color` so poster frames and row cards actually render their borders
- adds shared list styles for row cards, posters, titles, years, and section containers
- centralizes shared section-heading styling for movie lists, unmatched movies, relative dates, and empty states
- collapses the duplicate `PageTitle` / `PageSection` style logic into a shared `PageHeading` component

Checks:
- `pnpm --dir web exec prettier --check components/PageHeading.tsx components/PageTitle.tsx components/PageSection.tsx components/listStyles.ts components/MoviesOverview.tsx components/UnmatchedMoviesOverview.tsx components/Screening.tsx components/RelativeDate.tsx components/Calendar/index.tsx styles/globals.css`
- `pnpm --dir web exec eslint components/PageHeading.tsx components/PageTitle.tsx components/PageSection.tsx components/listStyles.tsx components/MoviesOverview.tsx components/UnmatchedMoviesOverview.tsx components/Screening.tsx components/RelativeDate.tsx components/Calendar/index.tsx`
- `pnpm exec tsc --noEmit --pretty false` in `web`