### PR TITLE
Add search to movie list

### DIFF
--- a/web/app/movie/page.tsx
+++ b/web/app/movie/page.tsx
@@ -22,7 +22,9 @@ export default async function MoviesPage() {
           <NavigationBar />
         </Suspense>
       </Layout>
-      <MoviesOverview movies={movies} />
+      <Suspense>
+        <MoviesOverview movies={movies} />
+      </Suspense>
     </>
   )
 }

--- a/web/app/movie/unmatched/page.tsx
+++ b/web/app/movie/unmatched/page.tsx
@@ -26,7 +26,9 @@ export default async function UnmatchedMoviesPage() {
           <NavigationBar />
         </Suspense>
       </Layout>
-      <UnmatchedMoviesOverview screenings={screenings} />
+      <Suspense>
+        <UnmatchedMoviesOverview screenings={screenings} />
+      </Suspense>
     </>
   )
 }

--- a/web/components/Calendar/index.tsx
+++ b/web/components/Calendar/index.tsx
@@ -15,8 +15,8 @@ import {
 } from '../../utils/groupAndSortScreenings'
 import { getMoviePagePath } from '../../utils/getMoviePagePath'
 import { useSearch } from '../../utils/hooks'
+import { matchesScreeningSearch } from '../../utils/searchMatches'
 import { DirectCalendar } from './DirectCalendar'
-import { removeDiacritics } from '../../utils/removeDiacritics'
 import { listSectionHeadingStyle } from '../listStyles'
 
 export type Row =
@@ -30,25 +30,6 @@ const containerStyle = css({
   marginTop: '24px',
   marginBottom: '24px',
 })
-
-const screeningMatchesSearch = (
-  screening: ScreeningWithLuxonDate,
-  searchComponents: string[],
-) => {
-  const title = removeDiacritics(screening.title.toLowerCase())
-  const cinema = removeDiacritics(screening.cinema.name.toLowerCase())
-  const city = removeDiacritics(screening.cinema.city.name.toLowerCase())
-
-  return (
-    searchComponents.length === 0 ||
-    searchComponents.every(
-      (searchComponent) =>
-        title.includes(searchComponent) ||
-        cinema.includes(searchComponent) ||
-        city.includes(searchComponent),
-    )
-  )
-}
 
 export const Calendar = ({
   screenings,
@@ -73,7 +54,7 @@ export const Calendar = ({
 
   const rows = screeningsByDate.flatMap(([date, screenings]) => {
     const filteredScreenings = screenings?.filter((screening) =>
-      screeningMatchesSearch(screening, searchComponents),
+      matchesScreeningSearch(screening, searchComponents),
     )
 
     if (!filteredScreenings?.length) return []

--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -229,7 +229,7 @@ export const MoviePage = ({
     <>
       <Suspense>
         <Layout backgroundColor={palette.purple600}>
-          <NavigationBar showSearch={false} />
+          <NavigationBar />
         </Layout>
       </Suspense>
       <Layout>

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -56,7 +56,8 @@ const rowStyle = css({
   gridColumnGap: '12px',
 })
 
-const rowClassName = cx(listRowBaseStyle, rowStyle)
+const rowClassName = (className?: string) =>
+  cx(listRowBaseStyle, rowStyle, className)
 
 const getMovieSection = (title: string) => {
   const firstLetter = title.trim().charAt(0).toUpperCase()
@@ -64,7 +65,17 @@ const getMovieSection = (title: string) => {
   return firstLetter >= 'A' && firstLetter <= 'Z' ? firstLetter : '#'
 }
 
-const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
+export const MovieOverviewRow = ({
+  movie,
+  href,
+  className,
+  posterPlaceholderClassName,
+}: {
+  movie: Movie
+  href?: string
+  className?: string
+  posterPlaceholderClassName?: string
+}) => {
   const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath)
   const year = getMovieReleaseYear(movie)
   const content = (
@@ -79,7 +90,10 @@ const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
           className={listPosterStyle}
         />
       ) : (
-        <div aria-hidden className={listPosterPlaceholderStyle} />
+        <div
+          aria-hidden
+          className={cx(listPosterPlaceholderStyle, posterPlaceholderClassName)}
+        />
       )}
       <div className={listTitleStyle}>
         {movie.title}
@@ -88,15 +102,18 @@ const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
     </>
   )
 
-  if (movie.slug) {
+  if (href || movie.slug) {
     return (
-      <Link href={`/movie/${movie.slug}`} className={rowClassName}>
+      <Link
+        href={href ?? `/movie/${movie.slug}`}
+        className={rowClassName(className)}
+      >
         {content}
       </Link>
     )
   }
 
-  return <div className={rowClassName}>{content}</div>
+  return <div className={rowClassName(className)}>{content}</div>
 }
 
 export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -7,12 +7,12 @@ import React from 'react'
 import { css, cx } from 'styled-system/css'
 
 import { useSearch } from '../utils/hooks'
-import { removeDiacritics } from '../utils/removeDiacritics'
 import {
   getMoviePosterUrl,
   getMovieReleaseYear,
   Movie,
 } from '../utils/getMovies'
+import { matchesMovieSearch } from '../utils/searchMatches'
 import { Layout } from './Layout'
 import {
   listContainerStyle,
@@ -64,21 +64,6 @@ const getMovieSection = (title: string) => {
   return firstLetter >= 'A' && firstLetter <= 'Z' ? firstLetter : '#'
 }
 
-const movieMatchesSearch = (movie: Movie, searchComponents: string[]) => {
-  const title = removeDiacritics(movie.title.toLowerCase())
-  const sortTitle = removeDiacritics(
-    (movie.sortTitle ?? movie.title).toLowerCase(),
-  )
-
-  return (
-    searchComponents.length === 0 ||
-    searchComponents.every(
-      (searchComponent) =>
-        title.includes(searchComponent) || sortTitle.includes(searchComponent),
-    )
-  )
-}
-
 const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
   const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath)
   const year = getMovieReleaseYear(movie)
@@ -118,7 +103,7 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
   const { search, searchComponents } = useSearch()
 
   const sortedMovies = movies
-    .filter((movie) => movieMatchesSearch(movie, searchComponents))
+    .filter((movie) => matchesMovieSearch(movie, searchComponents))
     .sort((left, right) =>
       (left.sortTitle ?? left.title).localeCompare(
         right.sortTitle ?? right.title,

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -1,26 +1,30 @@
+'use client'
+
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'
 
 import { css, cx } from 'styled-system/css'
 
+import { useSearch } from '../utils/hooks'
+import { removeDiacritics } from '../utils/removeDiacritics'
 import {
   getMoviePosterUrl,
   getMovieReleaseYear,
   Movie,
 } from '../utils/getMovies'
 import { Layout } from './Layout'
-import { PageTitle } from './PageTitle'
-import { PageSection } from './PageSection'
 import {
   listContainerStyle,
-  listSectionHeadingStyle,
   listPosterPlaceholderStyle,
   listPosterStyle,
   listRowBaseStyle,
+  listSectionHeadingStyle,
   listTitleStyle,
   listYearStyle,
 } from './listStyles'
+import { PageSection } from './PageSection'
+import { PageTitle } from './PageTitle'
 
 const pageStyle = css({
   marginTop: '16px',
@@ -60,6 +64,21 @@ const getMovieSection = (title: string) => {
   return firstLetter >= 'A' && firstLetter <= 'Z' ? firstLetter : '#'
 }
 
+const movieMatchesSearch = (movie: Movie, searchComponents: string[]) => {
+  const title = removeDiacritics(movie.title.toLowerCase())
+  const sortTitle = removeDiacritics(
+    (movie.sortTitle ?? movie.title).toLowerCase(),
+  )
+
+  return (
+    searchComponents.length === 0 ||
+    searchComponents.every(
+      (searchComponent) =>
+        title.includes(searchComponent) || sortTitle.includes(searchComponent),
+    )
+  )
+}
+
 const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
   const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath)
   const year = getMovieReleaseYear(movie)
@@ -96,13 +115,17 @@ const MovieOverviewRow = ({ movie }: { movie: Movie }) => {
 }
 
 export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
-  const sortedMovies = [...movies].sort((left, right) =>
-    (left.sortTitle ?? left.title).localeCompare(
-      right.sortTitle ?? right.title,
-      undefined,
-      { sensitivity: 'base' },
-    ),
-  )
+  const { search, searchComponents } = useSearch()
+
+  const sortedMovies = movies
+    .filter((movie) => movieMatchesSearch(movie, searchComponents))
+    .sort((left, right) =>
+      (left.sortTitle ?? left.title).localeCompare(
+        right.sortTitle ?? right.title,
+        undefined,
+        { sensitivity: 'base' },
+      ),
+    )
 
   const moviesBySection = sortedMovies.reduce<Record<string, Movie[]>>(
     (sections, movie) => {
@@ -136,16 +159,22 @@ export const MoviesOverview = ({ movies }: { movies: Movie[] }) => {
             scheduled.
           </p>
         </div>
-        <div className={listContainerStyle}>
-          {sections.map((section) => (
-            <div key={section}>
-              <h3 className={listSectionHeadingStyle}>{section}</h3>
-              {moviesBySection[section].map((movie) => (
-                <MovieOverviewRow key={movie.movieId} movie={movie} />
-              ))}
-            </div>
-          ))}
-        </div>
+        {sortedMovies.length === 0 ? (
+          <h3 className={listSectionHeadingStyle}>
+            No movies found{search ? ` for ${search}` : ''}
+          </h3>
+        ) : (
+          <div className={listContainerStyle}>
+            {sections.map((section) => (
+              <div key={section}>
+                <h3 className={listSectionHeadingStyle}>{section}</h3>
+                {moviesBySection[section].map((movie) => (
+                  <MovieOverviewRow key={movie.movieId} movie={movie} />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
         <div className={footerStyle}>
           <PageSection>Unmatched movies</PageSection>
           <p>

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import Link from 'next/link'
 

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -8,7 +8,8 @@ import { css, cx } from 'styled-system/css'
 import { useSearch } from '../utils/hooks'
 import { Screening } from '../utils/getScreenings'
 import { palette } from '../utils/theme'
-import { matchesScreeningSearch } from '../utils/searchMatches'
+import type { Movie } from '../utils/getMovies'
+import { matchesMovieSearch } from '../utils/searchMatches'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
 import {
@@ -59,6 +60,17 @@ const getMovieSection = (title: string) => {
 
 const getUnmatchedMovieKey = (screening: Screening) =>
   `${screening.title}__${screening.year ?? ''}`
+
+const toMovie = (screening: Screening): Movie => ({
+  movieId: getUnmatchedMovieKey(screening),
+  title: screening.title,
+  tmdbId: 0,
+  tmdb: screening.year
+    ? {
+        releaseDate: `${screening.year}-01-01`,
+      }
+    : undefined,
+})
 
 const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
   <Link
@@ -114,7 +126,7 @@ export const UnmatchedMoviesOverview = ({
   })
 
   const filteredMovies = uniqueUnmatchedMovies.filter((screening) =>
-    matchesScreeningSearch(screening, searchComponents),
+    matchesMovieSearch(toMovie(screening), searchComponents),
   )
 
   const moviesBySection = filteredMovies.reduce<Record<string, Screening[]>>(

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -8,7 +8,7 @@ import { css, cx } from 'styled-system/css'
 import { useSearch } from '../utils/hooks'
 import { Screening } from '../utils/getScreenings'
 import { palette } from '../utils/theme'
-import { matchesUnmatchedMovieSearch } from '../utils/searchMatches'
+import { matchesScreeningSearch } from '../utils/searchMatches'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
 import {
@@ -114,7 +114,7 @@ export const UnmatchedMoviesOverview = ({
   })
 
   const filteredMovies = uniqueUnmatchedMovies.filter((screening) =>
-    matchesUnmatchedMovieSearch(screening, searchComponents),
+    matchesScreeningSearch(screening, searchComponents),
   )
 
   const moviesBySection = filteredMovies.reduce<Record<string, Screening[]>>(

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -6,9 +6,9 @@ import Link from 'next/link'
 import { css, cx } from 'styled-system/css'
 
 import { useSearch } from '../utils/hooks'
-import { removeDiacritics } from '../utils/removeDiacritics'
 import { Screening } from '../utils/getScreenings'
 import { palette } from '../utils/theme'
+import { matchesUnmatchedMovieSearch } from '../utils/searchMatches'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
 import {
@@ -59,22 +59,6 @@ const getMovieSection = (title: string) => {
 
 const getUnmatchedMovieKey = (screening: Screening) =>
   `${screening.title}__${screening.year ?? ''}`
-
-const screeningMatchesSearch = (
-  screening: Screening,
-  searchComponents: string[],
-) => {
-  const title = removeDiacritics(screening.title.toLowerCase())
-  const year = screening.year?.toString() ?? ''
-
-  return (
-    searchComponents.length === 0 ||
-    searchComponents.every(
-      (searchComponent) =>
-        title.includes(searchComponent) || year.includes(searchComponent),
-    )
-  )
-}
 
 const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
   <Link
@@ -130,7 +114,7 @@ export const UnmatchedMoviesOverview = ({
   })
 
   const filteredMovies = uniqueUnmatchedMovies.filter((screening) =>
-    screeningMatchesSearch(screening, searchComponents),
+    matchesUnmatchedMovieSearch(screening, searchComponents),
   )
 
   const moviesBySection = filteredMovies.reduce<Record<string, Screening[]>>(

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 
 import { css, cx } from 'styled-system/css'
 
+import { useSearch } from '../utils/hooks'
+import { removeDiacritics } from '../utils/removeDiacritics'
 import { Screening } from '../utils/getScreenings'
 import { palette } from '../utils/theme'
 import { Layout } from './Layout'
@@ -56,6 +58,22 @@ const getMovieSection = (title: string) => {
 const getUnmatchedMovieKey = (screening: Screening) =>
   `${screening.title}__${screening.year ?? ''}`
 
+const screeningMatchesSearch = (
+  screening: Screening,
+  searchComponents: string[],
+) => {
+  const title = removeDiacritics(screening.title.toLowerCase())
+  const year = screening.year?.toString() ?? ''
+
+  return (
+    searchComponents.length === 0 ||
+    searchComponents.every(
+      (searchComponent) =>
+        title.includes(searchComponent) || year.includes(searchComponent),
+    )
+  )
+}
+
 const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
   <Link
     href={`/?search=${encodeURIComponent(screening.title)}`}
@@ -82,6 +100,8 @@ export const UnmatchedMoviesOverview = ({
 }: {
   screenings: Screening[]
 }) => {
+  const { search, searchComponents } = useSearch()
+
   const unmatchedMovies = screenings.filter((screening) => !screening.movieId)
 
   const uniqueUnmatchedMovies = Array.from(
@@ -107,14 +127,19 @@ export const UnmatchedMoviesOverview = ({
     return (right.year ?? 0) - (left.year ?? 0)
   })
 
-  const moviesBySection = uniqueUnmatchedMovies.reduce<
-    Record<string, Screening[]>
-  >((sections, screening) => {
-    const section = getMovieSection(screening.title)
-    sections[section] = sections[section] ?? []
-    sections[section].push(screening)
-    return sections
-  }, {})
+  const filteredMovies = uniqueUnmatchedMovies.filter((screening) =>
+    screeningMatchesSearch(screening, searchComponents),
+  )
+
+  const moviesBySection = filteredMovies.reduce<Record<string, Screening[]>>(
+    (sections, screening) => {
+      const section = getMovieSection(screening.title)
+      sections[section] = sections[section] ?? []
+      sections[section].push(screening)
+      return sections
+    },
+    {},
+  )
 
   const sections = Object.keys(moviesBySection).sort((left, right) => {
     if (left === '#') {
@@ -138,19 +163,25 @@ export const UnmatchedMoviesOverview = ({
             Database.
           </p>
         </div>
-        <div className={listContainerStyle}>
-          {sections.map((section) => (
-            <div key={section}>
-              <h3 className={listSectionHeadingStyle}>{section}</h3>
-              {moviesBySection[section].map((screening) => (
-                <UnmatchedMovieRow
-                  key={getUnmatchedMovieKey(screening)}
-                  screening={screening}
-                />
-              ))}
-            </div>
-          ))}
-        </div>
+        {filteredMovies.length === 0 ? (
+          <h3 className={listSectionHeadingStyle}>
+            No movies found{search ? ` for ${search}` : ''}
+          </h3>
+        ) : (
+          <div className={listContainerStyle}>
+            {sections.map((section) => (
+              <div key={section}>
+                <h3 className={listSectionHeadingStyle}>{section}</h3>
+                {moviesBySection[section].map((screening) => (
+                  <UnmatchedMovieRow
+                    key={getUnmatchedMovieKey(screening)}
+                    screening={screening}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </Layout>
   )

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React from 'react'
-import Link from 'next/link'
 
 import { css, cx } from 'styled-system/css'
 
@@ -10,16 +9,10 @@ import { Screening } from '../utils/getScreenings'
 import { palette } from '../utils/theme'
 import type { Movie } from '../utils/getMovies'
 import { matchesMovieSearch } from '../utils/searchMatches'
+import { MovieOverviewRow } from './MoviesOverview'
 import { Layout } from './Layout'
 import { PageTitle } from './PageTitle'
-import {
-  listContainerStyle,
-  listSectionHeadingStyle,
-  listPosterPlaceholderStyle,
-  listRowBaseStyle,
-  listTitleStyle,
-  listYearStyle,
-} from './listStyles'
+import { listContainerStyle, listSectionHeadingStyle } from './listStyles'
 
 const pageStyle = css({
   marginTop: '16px',
@@ -37,10 +30,7 @@ const introStyle = css({
 })
 
 const rowStyle = cx(
-  listRowBaseStyle,
   css({
-    display: 'grid',
-    gridTemplateColumns: 'auto minmax(0, 1fr)',
     '&:hover': {
       backgroundColor: 'var(--background-highlight-color)',
       borderRadius: '10px',
@@ -71,27 +61,6 @@ const toMovie = (screening: Screening): Movie => ({
       }
     : undefined,
 })
-
-const UnmatchedMovieRow = ({ screening }: { screening: Screening }) => (
-  <Link
-    href={`/?search=${encodeURIComponent(screening.title)}`}
-    className={rowStyle}
-  >
-    <div
-      aria-hidden
-      className={cx(
-        listPosterPlaceholderStyle,
-        'unmatched-movie-poster-placeholder',
-      )}
-    />
-    <div className={listTitleStyle}>
-      {screening.title}
-      {screening.year ? (
-        <span className={listYearStyle}> ({screening.year})</span>
-      ) : null}
-    </div>
-  </Link>
-)
 
 export const UnmatchedMoviesOverview = ({
   screenings,
@@ -171,9 +140,12 @@ export const UnmatchedMoviesOverview = ({
               <div key={section}>
                 <h3 className={listSectionHeadingStyle}>{section}</h3>
                 {moviesBySection[section].map((screening) => (
-                  <UnmatchedMovieRow
+                  <MovieOverviewRow
                     key={getUnmatchedMovieKey(screening)}
-                    screening={screening}
+                    movie={toMovie(screening)}
+                    href={`/?search=${encodeURIComponent(screening.title)}`}
+                    className={rowStyle}
+                    posterPlaceholderClassName="unmatched-movie-poster-placeholder"
                   />
                 ))}
               </div>

--- a/web/utils/searchMatches.ts
+++ b/web/utils/searchMatches.ts
@@ -1,0 +1,54 @@
+import type { Movie } from './getMovies'
+import type { Screening } from './getScreenings'
+import { removeDiacritics } from './removeDiacritics'
+
+const normalize = (value: string) => removeDiacritics(value.toLowerCase())
+
+type ScreeningSearchTarget = {
+  title: string
+  cinema: {
+    name: string
+    city: {
+      name: string
+    }
+  }
+}
+
+export const matchesSearchComponents = (
+  values: string[],
+  searchComponents: string[],
+) => {
+  if (searchComponents.length === 0) {
+    return true
+  }
+
+  const normalizedValues = values.map(normalize)
+
+  return searchComponents.every((searchComponent) =>
+    normalizedValues.some((value) => value.includes(searchComponent)),
+  )
+}
+
+export const matchesScreeningSearch = <T extends ScreeningSearchTarget>(
+  screening: T,
+  searchComponents: string[],
+) =>
+  matchesSearchComponents(
+    [screening.title, screening.cinema.name, screening.cinema.city.name],
+    searchComponents,
+  )
+
+export const matchesMovieSearch = (movie: Movie, searchComponents: string[]) =>
+  matchesSearchComponents(
+    [movie.title, movie.sortTitle ?? movie.title],
+    searchComponents,
+  )
+
+export const matchesUnmatchedMovieSearch = (
+  screening: Screening,
+  searchComponents: string[],
+) =>
+  matchesSearchComponents(
+    [screening.title, screening.year?.toString() ?? ''],
+    searchComponents,
+  )

--- a/web/utils/searchMatches.ts
+++ b/web/utils/searchMatches.ts
@@ -1,11 +1,13 @@
 import type { Movie } from './getMovies'
 import type { Screening } from './getScreenings'
+import { getMovieReleaseYear } from './getMovies'
 import { removeDiacritics } from './removeDiacritics'
 
 const normalize = (value: string) => removeDiacritics(value.toLowerCase())
 
 type ScreeningSearchTarget = {
   title: string
+  year?: number
   cinema: {
     name: string
     city: {
@@ -34,21 +36,17 @@ export const matchesScreeningSearch = <T extends ScreeningSearchTarget>(
   searchComponents: string[],
 ) =>
   matchesSearchComponents(
-    [screening.title, screening.cinema.name, screening.cinema.city.name],
+    [
+      screening.title,
+      screening.year?.toString() ?? '',
+      screening.cinema.name,
+      screening.cinema.city.name,
+    ],
     searchComponents,
   )
 
 export const matchesMovieSearch = (movie: Movie, searchComponents: string[]) =>
   matchesSearchComponents(
-    [movie.title, movie.sortTitle ?? movie.title],
-    searchComponents,
-  )
-
-export const matchesUnmatchedMovieSearch = (
-  screening: Screening,
-  searchComponents: string[],
-) =>
-  matchesSearchComponents(
-    [screening.title, screening.year?.toString() ?? ''],
+    [movie.title, getMovieReleaseYear(movie)?.toString() ?? ''],
     searchComponents,
   )


### PR DESCRIPTION
Adds search behavior to the `/movie` overview so it filters by the shared `search` query parameter like the screening pages do.

The movie list now:
- reads `?search=` from the URL
- filters movies by title and sort title
- shows an empty state when nothing matches
- keeps the existing search bar / `/` keyboard shortcut behavior in the navigation

Checks:
- `pnpm --dir web exec prettier --check components/MoviesOverview.tsx app/movie/page.tsx`
- `pnpm --dir web exec eslint components/MoviesOverview.tsx app/movie/page.tsx`
- `pnpm exec tsc --noEmit --pretty false` in `web`