### PR TITLE
Fix screening visibility timezone handling

### DIFF
--- a/web/components/RelativeDate.tsx
+++ b/web/components/RelativeDate.tsx
@@ -6,7 +6,7 @@ import { getToday } from '../utils/getToday'
 import { listSectionHeadingStyle } from './listStyles'
 
 export const RelativeDate = ({ children }: { children: string }) => {
-  const date = DateTime.fromISO(children)
+  const date = DateTime.fromISO(children, { zone: 'Europe/Amsterdam' })
   const today = getToday()
 
   const diff = date.diff(today, 'days').days

--- a/web/utils/getToday.ts
+++ b/web/utils/getToday.ts
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon'
 
 export const getToday = () => {
-  const { year, month, day } = DateTime.local()
-  return DateTime.fromObject({ year, month, day })
+  return DateTime.now().setZone('Europe/Amsterdam').startOf('day')
 }

--- a/web/utils/groupAndSortScreenings.ts
+++ b/web/utils/groupAndSortScreenings.ts
@@ -15,7 +15,12 @@ export const groupAndSortScreenings = (
   screenings: Screening[],
 ): Partial<Record<string, ScreeningWithLuxonDate[]>> => {
   const sorted = screenings
-    .map((x) => ({ ...x, date: DateTime.fromISO(x.date) })) // use luxon on the date
+    .map((x) => ({
+      ...x,
+      date: DateTime.fromISO(x.date, { setZone: true }).setZone(
+        'Europe/Amsterdam',
+      ),
+    }))
     .filter((x) => x.date >= getToday())
     .sort((a, b) => a.date.toMillis() - b.date.toMillis())
 


### PR DESCRIPTION
Fix the screening visibility cutoff and relative date labels so they use Europe/Amsterdam consistently.

Validation:
- `pnpm --dir web exec eslint components/RelativeDate.tsx utils/getToday.ts utils/groupAndSortScreenings.ts`
- `pnpm --dir web exec prettier --check components/RelativeDate.tsx utils/getToday.ts utils/groupAndSortScreenings.ts`