### PR TITLE
Tighten cloud compile-time checks

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -38,12 +38,7 @@ jobs:
       - name: Run Tests
         run: pnpm test
       - name: Type Check
-        id: typecheck
-        continue-on-error: true
         run: pnpm type-check
-      - name: Warn on Type Check Failure
-        if: steps.typecheck.outcome == 'failure'
-        run: echo "::warning::cloud type-check failed; this is currently non-blocking"
       - name: CDK Synth
         env:
           STAGE: dev

--- a/cloud/.gitignore
+++ b/cloud/.gitignore
@@ -1,6 +1,7 @@
 *.js
 !jest.config.js
 *.d.ts
+!types/*.d.ts
 node_modules
 
 # CDK asset staging directory

--- a/cloud/bin/backend.ts
+++ b/cloud/bin/backend.ts
@@ -7,7 +7,7 @@ import { BackendStack } from '../lib/backend-stack'
 dotenv.config({ quiet: true })
 
 const app = new cdk.App()
-const stage = process.env.STAGE || 'prod'
+const stage: 'dev' | 'prod' = process.env.STAGE === 'dev' ? 'dev' : 'prod'
 
 new BackendStack(app, `expatcinema-${stage}`, {
   description: 'expatcinema.com',

--- a/cloud/browser.ts
+++ b/cloud/browser.ts
@@ -4,10 +4,15 @@ import puppeteer, { Browser, LaunchOptions } from 'puppeteer-core'
 
 import { LOCAL_CHROMIUM_EXECUTABLE_PATH } from './browser-local-constants'
 
+type InitializationEntry = {
+  resolve: (browser: Browser) => void
+  reject: (error: unknown) => void
+}
+
 const createBrowserSingleton = () => {
-  let instance: Browser
+  let instance: Browser | undefined
   let isInitializing = false
-  const initializationQueue = []
+  const initializationQueue: InitializationEntry[] = []
 
   const initializeBrowser = async ({ logger }: { logger?: Logger }) => {
     try {
@@ -30,24 +35,26 @@ const createBrowserSingleton = () => {
 
       logger?.info('launching browser', { options })
       instance = await puppeteer.launch(options)
-      isInitializing = false
       logger?.info('browser launched')
-
-      // Resolve all pending promises in the queue
-      let i = 0
-      while (initializationQueue.length) {
-        logger?.info(`resolving pending promises in the queue: ${i++}`)
-        const resolver = initializationQueue.shift()
-        resolver(instance)
-      }
     } catch (error) {
-      // Reject all pending promises in the queue on error
-      let i = 0
-      while (initializationQueue.length) {
-        logger?.info(`resolving pending promises in the queue: ${i++}`)
-        const resolver = initializationQueue.shift()
-        resolver(Promise.reject(error))
-      }
+      instance = undefined
+      throw error
+    } finally {
+      isInitializing = false
+
+      const pendingRequests = initializationQueue.splice(0)
+      pendingRequests.forEach(({ resolve, reject }, index) => {
+        logger?.info('settling pending browser initialization request', {
+          index,
+          hasInstance: Boolean(instance),
+        })
+
+        if (instance) {
+          resolve(instance)
+        } else {
+          reject(new Error('browser initialization failed'))
+        }
+      })
     }
   }
 
@@ -60,13 +67,17 @@ const createBrowserSingleton = () => {
 
     if (isInitializing) {
       logger?.info('browser is initializing')
-      // If initialization is in progress, return a promise that resolves when it's done
-      return new Promise((resolve) => {
-        initializationQueue.push(resolve)
+      // If initialization is in progress, return a promise that settles when it's done
+      return new Promise<Browser>((resolve, reject) => {
+        initializationQueue.push({ resolve, reject })
       })
     } else {
       logger?.info('browser is initialized')
       // If instance is available, return it
+      if (!instance) {
+        throw new Error('browser failed to initialize')
+      }
+
       return instance
     }
   }

--- a/cloud/handler.ts
+++ b/cloud/handler.ts
@@ -4,13 +4,13 @@ import { handler as analytics } from './analytics'
 import { handler as fillAnalytics } from './fillAnalytics'
 import { handler as notifySlack } from './notifySlack'
 import { handler as playground } from './playground'
-import { handler as scrapers } from './scrapers/index.ts'
+import { scrapers } from './scrapers/index'
 
 const scrapersWrappedWithHTTP = async (
   event: APIGatewayEvent,
   context: Context,
 ) => {
-  await scrapers(event, context)
+  await scrapers()
 
   return {
     statusCode: 200,

--- a/cloud/notifySlack.ts
+++ b/cloud/notifySlack.ts
@@ -18,12 +18,32 @@ const filters = [
 
 const gunzip = util.promisify(zlib.gunzip)
 
-const notifySlack = async ({ awslogs } = {}) => {
+type CloudWatchLogsEvent = {
+  awslogs: {
+    data: string
+  }
+}
+
+type LogEvent = {
+  message: string
+}
+
+type SlackBlock = {
+  type: string
+  text: {
+    type: string
+    text: string
+  }
+}
+
+const notifySlack = async ({ awslogs }: CloudWatchLogsEvent) => {
   const payload = Buffer.from(awslogs.data, 'base64')
 
   const unzippedPayload = await gunzip(payload)
 
-  const { logEvents } = JSON.parse(unzippedPayload.toString())
+  const { logEvents } = JSON.parse(unzippedPayload.toString()) as {
+    logEvents: LogEvent[]
+  }
 
   const filteredLogEvents = logEvents.filter(({ message }) =>
     filters.some((f) => f.test(message)),
@@ -41,16 +61,19 @@ const levelsToEmoji = {
   DEBUG: ':information_source:',
 }
 
-const getSlackBlocks = (logEvent) => {
+const getSlackBlocks = (logEvent: LogEvent): SlackBlock[] => {
   try {
-    const json = JSON.parse(logEvent.message)
+    const json = JSON.parse(logEvent.message) as {
+      level?: keyof typeof levelsToEmoji
+      message: string
+    }
 
     const blocks = [
       {
         type: 'section',
         text: {
           type: 'plain_text',
-          text: `${levelsToEmoji[json.level]} ${json.message}`,
+          text: `${levelsToEmoji[json.level ?? 'INFO']} ${json.message}`,
         },
       },
       {
@@ -74,8 +97,13 @@ const getSlackBlocks = (logEvent) => {
   }
 }
 
-const postToSlack = (blocks) => {
-  return got.post(process.env.SLACK_WEBHOOK, {
+const postToSlack = (blocks: SlackBlock[]) => {
+  const slackWebhook = process.env.SLACK_WEBHOOK
+  if (!slackWebhook) {
+    throw new Error('SLACK_WEBHOOK is required')
+  }
+
+  return got.post(slackWebhook, {
     json: { blocks },
   })
 }

--- a/cloud/playground.ts
+++ b/cloud/playground.ts
@@ -65,7 +65,16 @@ const getUsingChromium = async () => {
 
   await page.waitForSelector('body')
   const textContent = await page.evaluate(
-    () => document.querySelector('a').textContent,
+    () =>
+      (
+        globalThis as unknown as {
+          document: {
+            querySelector: (selector: string) => {
+              textContent?: string | null
+            } | null
+          }
+        }
+      ).document.querySelector('a')?.textContent,
   )
 
   logger.info('First link' + textContent)
@@ -84,9 +93,13 @@ const movieMetadataPlayground = async () => {
       new Set(screenings.map(({ title }) => title)),
     ).sort()
 
-    const uniqueTitlesAndMetadata = await pMap(uniqueTitles, getMetadata, {
-      concurrency: 5,
-    })
+    const uniqueTitlesAndMetadata = await pMap(
+      uniqueTitles.map((title) => ({ title })),
+      getMetadata,
+      {
+        concurrency: 5,
+      },
+    )
 
     const allWithMovieId = screenings.map((screening) => {
       const metadata = uniqueTitlesAndMetadata.find(

--- a/cloud/scrapers.ts
+++ b/cloud/scrapers.ts
@@ -2,7 +2,7 @@ import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware'
 import middy from '@middy/core'
 
 import { logger as parentLogger } from './powertools'
-import { scrapers } from './scrapers/index.ts'
+import { scrapers } from './scrapers/index'
 
 const logger = parentLogger.createChild({
   persistentLogAttributes: {

--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -1,7 +1,7 @@
 import got from 'got'
 import { DateTime } from 'luxon'
 import Xray from 'x-ray'
-import XRayCrawler from 'x-ray-crawler'
+import { type Driver } from 'x-ray-crawler'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
@@ -19,7 +19,7 @@ const logger = parentLogger.createChild({
 // De Uitkijk has a certificate for which the intermediate certificate is not included in the default Node.js certificate store.
 // Using a custom got driver that ignores certificate errors feels like a reasonable workaround, and definitely
 // better than setting NODE_TLS_REJECT_UNAUTHORIZED=0 for all scrapers.
-const driver: XRayCrawler.Driver = (context, callback) => {
+const driver: Driver = (context, callback) => {
   const { url } = context
 
   got(String(url), { https: { rejectUnauthorized: false } })

--- a/cloud/scrapers/dokhuis.ts
+++ b/cloud/scrapers/dokhuis.ts
@@ -23,6 +23,11 @@ type XRayFromMoviePage = {
   time: string
 }
 
+type DokhuisMovie = {
+  title?: string
+  url?: string
+}
+
 const extractFromMoviePage = async ({
   url,
 }: {
@@ -78,15 +83,17 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   // easy way to go through the entire agenda
   const url = 'https://dokhuis.org/programma/'
 
-  const xrayResult = await xray(url, '.events-items .event-item', [
+  const xrayResult = (await xray(url, '.events-items .event-item', [
     {
       title: '.event-title',
       url: 'a@href',
     },
-  ])
+  ])) as DokhuisMovie[]
 
   const movies = xrayResult
-    .filter(({ url }) => url !== undefined) // remove movies without url (e.g. in the past)
+    .filter((item): item is DokhuisMovie & { url: string; title: string } =>
+      Boolean(item.url && item.title),
+    ) // remove movies without url (e.g. in the past)
     .filter(({ title }) =>
       title.toLowerCase().includes('movie night: acts of care'),
     ) // only events with "Movie Night: Acts of care" in the title have English subtitles

--- a/cloud/scrapers/eyefilm.ts
+++ b/cloud/scrapers/eyefilm.ts
@@ -84,12 +84,14 @@ const extractFromGraphQL = async (): Promise<Screening[]> => {
     },
   })
 
-  const hasEnglishSubtitles = (show) =>
+  const hasEnglishSubtitles = (show: EyeShow) =>
     show.singleSubtitles === '42c27a5b-2d4e-4195-b547-cb6fbe9fcd49'
 
-  logger.info('number of shows', { count: results.data.shows.length })
+  const shows = results.data?.shows ?? []
 
-  const screenings = results.data.shows
+  logger.info('number of shows', { count: shows.length })
+
+  const screenings = shows
     .filter(hasEnglishSubtitles)
     .map((show) => {
       return {

--- a/cloud/scrapers/filmhuisdenhaag.ts
+++ b/cloud/scrapers/filmhuisdenhaag.ts
@@ -73,6 +73,15 @@ type FilmhuisDenhaagAPIResponse = {
   }
 }
 
+type ProgramItem = {
+  title: string
+  subtitle?: string
+  characteristics?: string[]
+  uri: string
+  starts_at_date: string
+  starts_at_time: string
+}
+
 const cleanTitle = (title: string) =>
   titleCase(
     title
@@ -83,11 +92,11 @@ const cleanTitle = (title: string) =>
       ), // remove presentation-only suffixes
   )
 
-const hasEnglishSubtitles = (item) => {
+const hasEnglishSubtitles = (item: ProgramItem) => {
   return (
     item.subtitle === 'Engels' ||
     item.subtitle === 'English' ||
-    item.characteristics.includes('EN subs')
+    (item.characteristics ?? []).includes('EN subs')
   )
 }
 
@@ -139,7 +148,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     .map((item) => {
       const [year, month, day] = item.starts_at_date
         .split('-')
-        .map((x) => Number(x))
+        .map((x: string) => Number(x))
       const [hour, minute] = splitTime(item.starts_at_time)
 
       return {

--- a/cloud/scrapers/filmkoepel.ts
+++ b/cloud/scrapers/filmkoepel.ts
@@ -52,7 +52,7 @@ const extractFromSpecialExpatCinemaPage = async () => {
 
   const screenings: Screening[] = movies.flatMap(
     ({ title, url, screenings }) => {
-      return screenings
+        return screenings
         .filter((screening) => screening.includes('EN SUBS'))
         .map((screening) => {
           let day, month
@@ -78,10 +78,12 @@ const extractFromSpecialExpatCinemaPage = async () => {
             month = monthToNumber(monthString)
           }
 
-          const [hour, minute] = screening
-            .match(/\d\d:\d\d/)[0]
-            .split(':')
-            .map(Number)
+          const timeMatch = screening.match(/\d\d:\d\d/)
+          if (!timeMatch) {
+            throw new Error(`filmkoepel screening missing time: ${screening}`)
+          }
+
+          const [hour, minute] = timeMatch[0].split(':').map(Number)
 
           const year = guessYear({
             day,

--- a/cloud/scrapers/florafilmtheater.ts
+++ b/cloud/scrapers/florafilmtheater.ts
@@ -18,9 +18,10 @@ const logger = parentLogger.createChild({
   },
 })
 
-const trim = (value) => (typeof value === 'string' ? value.trim() : value)
+const trim = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : value
 
-const cleanTitle = (value) =>
+const cleanTitle = (value: unknown) =>
   typeof value === 'string'
     ? titleCase(
         // Flora appends both an `- En Subs` subtitle marker and, in some cases,
@@ -29,7 +30,7 @@ const cleanTitle = (value) =>
       )
     : value
 
-const normalizeWhitespace = (value) =>
+const normalizeWhitespace = (value: unknown) =>
   typeof value === 'string' ? value.replace(/\s+/g, ' ') : value
 
 const xray = Xray({

--- a/cloud/scrapers/focusarnhem.ts
+++ b/cloud/scrapers/focusarnhem.ts
@@ -16,22 +16,23 @@ const logger = parentLogger.createChild({
   },
 })
 
-const trim = (value) => (typeof value === 'string' ? value.trim() : value)
+const trim = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : value
 
-const cleanTitle = (value) =>
+const cleanTitle = (value: unknown): string =>
   typeof value === 'string'
     ? titleCase(
         value.replace(/^Expat Cinema: /gi, '').replace(/^English Subs: /gi, ''),
       )
-    : value
+    : ''
 
-const toLowerCase = (value) =>
+const toLowerCase = (value: unknown) =>
   typeof value === 'string' ? value.toLowerCase() : value
 
-const replaceNoBreakSpace = (value) =>
+const replaceNoBreakSpace = (value: unknown) =>
   typeof value === 'string' ? value.replace(/\u00a0/g, ' ') : value
 
-const normalizeWhitespace = (value) =>
+const normalizeWhitespace = (value: unknown) =>
   typeof value === 'string' ? value.replace(/\s+/g, ' ') : value
 
 const xray = Xray({

--- a/cloud/scrapers/hetdocumentairepaviljoen.ts
+++ b/cloud/scrapers/hetdocumentairepaviljoen.ts
@@ -20,6 +20,29 @@ type CinemaFilmDetail = {
   shows: CinemaFilmDetailShow[]
 }
 
+type SearchCinemaScheduleShow = {
+  id: string
+  fullTitle: string
+  film?: {
+    id: string
+    fullPreferredTitle: string
+  } | null
+}
+
+type DehydratedState = {
+  queries: Array<{
+    queryKey: string[]
+    state: {
+      data: {
+        film?: CinemaFilmDetail
+        searchCinemaSchedule?: {
+          hits: SearchCinemaScheduleShow[]
+        }
+      }
+    }
+  }>
+}
+
 type CinemaFilmDetailShow = {
   startOn: string
   endOn: string
@@ -50,9 +73,16 @@ const extractFromMoviePage = async (film: MainPageCinemaScheduleFilm) => {
   const { title, url, filmId } = film
   logger.info('extractFromMoviePage', { title, url, filmId })
 
-  const data = JSON.parse(await xray(url, '#__NEXT_DATA__'))
+  const data = JSON.parse(await xray(url, '#__NEXT_DATA__')) as {
+    props: {
+      pageProps: {
+        dehydratedState?: DehydratedState
+      }
+    }
+  }
 
-  if (!data.props.pageProps.dehydratedState) {
+  const dehydratedState = data.props.pageProps.dehydratedState
+  if (!dehydratedState) {
     logger.warn(
       `extractFromMoviePage: No dehydratedState: ${title} (${filmId} - ${url})`,
     )
@@ -61,10 +91,16 @@ const extractFromMoviePage = async (film: MainPageCinemaScheduleFilm) => {
 
   // logger.info('data', { data }) // uncomment to debug structure of __NEXT_DATA__
 
-  const filmDetail: CinemaFilmDetail =
-    data.props.pageProps.dehydratedState.queries.find(({ queryKey }) =>
-      queryKey.includes('CinemaFilmDetail'),
-    )?.state.data.film
+  const filmDetail = dehydratedState.queries.find(({ queryKey }) =>
+    queryKey.includes('CinemaFilmDetail'),
+  )?.state.data.film
+
+  if (!filmDetail) {
+    logger.warn(
+      `extractFromMoviePage: No film detail: ${title} (${filmId} - ${url})`,
+    )
+    return []
+  }
 
   const screenings: Screening[] = filmDetail.shows
     .filter(hasEnglishSubtitles)
@@ -96,11 +132,24 @@ const extractFromMainPage = async () => {
     'https://www.idfa.nl/en/vondelpark/agenda-het-documentaire-paviljoen/'
 
   // Use `copy(JSON.parse(document.querySelector('#__NEXT_DATA__').innerText))` to get an example of the data from Chrome DevTools
-  const data = JSON.parse(await xray(url, '#__NEXT_DATA__'))
+  const data = JSON.parse(await xray(url, '#__NEXT_DATA__')) as {
+    props: {
+      pageProps: {
+        dehydratedState?: DehydratedState
+      }
+    }
+  }
 
-  const shows = data.props.pageProps.dehydratedState.queries.find(
-    ({ queryKey }) => queryKey.includes('searchCinemaSchedule'),
-  )?.state.data.searchCinemaSchedule.hits
+  const dehydratedState = data.props.pageProps.dehydratedState
+  if (!dehydratedState) {
+    logger.warn(`extractFromMainPage: No dehydratedState: ${url}`)
+    return []
+  }
+
+  const shows =
+    dehydratedState.queries.find(({ queryKey }) =>
+      queryKey.includes('searchCinemaSchedule'),
+    )?.state.data.searchCinemaSchedule?.hits ?? []
 
   const films: MainPageCinemaScheduleFilm[] = shows
     .map((show) => {
@@ -117,7 +166,7 @@ const extractFromMainPage = async () => {
         filmId: show.film.id,
       }
     })
-    .filter((x) => x)
+    .filter((x): x is MainPageCinemaScheduleFilm => Boolean(x))
 
   // Filter out duplicate films
   const uniqueFilms = films.filter(

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -59,6 +59,7 @@ import {
   normalizeMovieTitleForLookup,
   slugifyMovieTitle,
 } from '../metadata/titleResolver'
+import type { Metadata } from '../metadata/types'
 
 const SCRAPERS = {
   bioscopenleiden,
@@ -113,6 +114,9 @@ const s3Client = new S3Client({})
 
 const PRIVATE_BUCKET = process.env.PRIVATE_BUCKET
 const PUBLIC_BUCKET = process.env.PUBLIC_BUCKET
+if (!PRIVATE_BUCKET || !PUBLIC_BUCKET) {
+  throw new Error('PRIVATE_BUCKET and PUBLIC_BUCKET must be set')
+}
 
 const now = DateTime.fromObject({}).toUTC().toISO()
 
@@ -367,7 +371,7 @@ export const scrapers = async () => {
       ).values(),
     )
 
-    const toTitleMatchRecord = (metadata) => ({
+    const toTitleMatchRecord = (metadata: Metadata) => ({
       query: metadata.query,
       year: metadata.year,
       titleRaw: Array.from(

--- a/cloud/scrapers/ketelhuis.ts
+++ b/cloud/scrapers/ketelhuis.ts
@@ -3,6 +3,7 @@ import pRetry from 'p-retry'
 import Xray from 'x-ray'
 
 import { logger as parentLogger } from '../powertools'
+import { Screening } from '../types'
 import xRayPuppeteer from '../xRayPuppeteer'
 import {
   fullMonthToNumberDutch,
@@ -23,7 +24,7 @@ const logger = parentLogger.createChild({
 const xray = Xray({
   filters: {
     trim,
-    cleanTitle: (value) =>
+    cleanTitle: (value: unknown) =>
       typeof value === 'string'
         ? titleCase(
             value
@@ -31,7 +32,7 @@ const xray = Xray({
               .replace(/ \(English subs\)$/i, ''),
           )
         : value,
-    normalizeWhitespace: (value) =>
+    normalizeWhitespace: (value: unknown) =>
       typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
   },
 })
@@ -39,6 +40,23 @@ const xray = Xray({
   .concurrency(3)
   .throttle(3, 600)
   .timeout('45s')
+
+type KetelhuisListing = {
+  url: string
+  title: string
+}
+
+type KetelhuisMoviePage = {
+  title: string
+  metadata: string
+  mainContent: string
+  firstDate: string
+  firstTimes: string[]
+  other: {
+    date: string
+    times: string[]
+  }[]
+}
 
 const extractFromMainPage = async () => {
   const selector = [
@@ -48,7 +66,7 @@ const extractFromMainPage = async () => {
     },
   ]
 
-  const expatCinemaResults = await pRetry(
+  const expatCinemaResults = await pRetry<KetelhuisListing[]>(
     async () =>
       xray(
         'https://www.ketelhuis.nl/specials/expat-cinema/',
@@ -74,7 +92,7 @@ const extractFromMainPage = async () => {
 
   const screenings = await (
     await Promise.all(
-      uniqueResults.map(async ({ url, title }, i) => {
+      uniqueResults.map(async ({ url, title }: KetelhuisListing, i) => {
         return pRetry(
           async () => {
             const result = await extractFromMoviePage({ url, title })
@@ -96,7 +114,15 @@ const extractFromMainPage = async () => {
   return screenings
 }
 
-const hasEnglishSubtitles = ({ metadata, mainContent, title }) =>
+const hasEnglishSubtitles = ({
+  metadata,
+  mainContent,
+  title,
+}: {
+  metadata?: string
+  mainContent?: string
+  title?: string
+}) =>
   title?.toLowerCase().includes('english subs') ||
   metadata?.toLowerCase().includes('english subtitles') ||
   metadata?.toLowerCase().includes('engels ondertiteld') ||
@@ -124,10 +150,22 @@ const splitFirstDate = (date: string) => {
   }
 }
 
-const extractFromMoviePage = async ({ url, title }) => {
+const toDateOrThrow = (date: DateTime, url: string) => {
+  const parsed = date.toJSDate()
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Could not format screening date for ${url}`)
+  }
+
+  return parsed
+}
+
+const extractFromMoviePage = async ({
+  url,
+  title,
+}: KetelhuisListing): Promise<Screening[]> => {
   logger.info('extracting', { url })
 
-  const scrapeResult = await xray(url, {
+  const scrapeResult = (await xray(url, {
     title: '.c-filmheader__content h1 > span', // not using cleanTitle because we want to keep the "English subs" part here
     metadata: '.c-detail-info__filminfo | normalizeWhitespace',
     mainContent: '.c-main-content | normalizeWhitespace',
@@ -139,7 +177,7 @@ const extractFromMoviePage = async ({ url, title }) => {
         times: ['.c-detail-schedule-complete__time'],
       },
     ]),
-  })
+  })) as KetelhuisMoviePage
 
   logger.info('extracted', { url, scrapeResult })
 
@@ -149,42 +187,46 @@ const extractFromMoviePage = async ({ url, title }) => {
     return []
   }
 
-  const firstDates = scrapeResult.firstTimes.map((time) => {
+  const firstDates = scrapeResult.firstTimes.map((time: string) => {
     const { day, month, year } = splitFirstDate(scrapeResult.firstDate)
 
     const [hour, minute] = splitTime(time)
 
-    return DateTime.fromObject({
-      day,
-      month,
-      hour,
-      minute,
-      year,
-    })
-      .toUTC()
-      .toISO()
-  })
-
-  const otherDates = scrapeResult.other.flatMap(({ date, times }) => {
-    const [dayString, monthString, yearString] = date.split(' ')
-    const day = Number(dayString)
-    const month = shortMonthToNumberDutch(monthString)
-    const year = Number(yearString)
-
-    return times.map((time) => {
-      const [hour, minute] = splitTime(time)
-
-      return DateTime.fromObject({
+    return toDateOrThrow(
+      DateTime.fromObject({
         day,
         month,
         hour,
         minute,
         year,
-      })
-        .toUTC()
-        .toISO()
-    })
+      }),
+      url,
+    )
   })
+
+  const otherDates = scrapeResult.other.flatMap(
+    ({ date, times }: KetelhuisMoviePage['other'][number]) => {
+      const [dayString, monthString, yearString] = date.split(' ')
+      const day = Number(dayString)
+      const month = shortMonthToNumberDutch(monthString)
+      const year = Number(yearString)
+
+      return times.map((time: string) => {
+        const [hour, minute] = splitTime(time)
+
+        return toDateOrThrow(
+          DateTime.fromObject({
+            day,
+            month,
+            hour,
+            minute,
+            year,
+          }),
+          url,
+        )
+      })
+    },
+  )
 
   const releaseYear = extractReleaseYear(scrapeResult.metadata ?? '')
 

--- a/cloud/scrapers/kriterion.ts
+++ b/cloud/scrapers/kriterion.ts
@@ -166,9 +166,14 @@ const extractFromMainPage = async () => {
       ),
     )
 
-    const releaseYearBySlug = new Map(
+    const releaseYearBySlug = new Map<string, number | undefined>(
       await Promise.all(
-        relevantSlugs.map(async (slug) => [slug, await extractCmsYear(slug)]),
+        relevantSlugs.map(
+          async (slug): Promise<[string, number | undefined]> => [
+            slug,
+            await extractCmsYear(slug),
+          ],
+        ),
       ),
     )
 

--- a/cloud/scrapers/liff.ts
+++ b/cloud/scrapers/liff.ts
@@ -20,12 +20,35 @@ const xray = Xray({
   .concurrency(10)
   .throttle(10, 300)
 
-const hasEnglishSubtitles = (movie) =>
-  movie.metadata.filter((x) => x === 'SubtitlesEnglish').length === (1).flat()
+type LiffMovie = {
+  title: string
+  url: string
+  metadata: string[]
+  firstScreening: {
+    date: string
+    time: string
+  }
+  restScreenings: {
+    date: string
+    time: string
+  }[]
+}
+
+type LiffListing = {
+  title: string
+  url: string
+}
+
+const hasEnglishSubtitles = (movie: Pick<LiffMovie, 'metadata'>) =>
+  movie.metadata.some((x) => x === 'SubtitlesEnglish')
 
 const cleanTitle = (title: string) => titleCase(title)
 
-const extractFromMoviePage = ({ url }) => {
+const extractFromMoviePage = ({
+  url,
+}: LiffListing): Promise<
+  { title: string; url: string; date: string; cinema: string }[]
+> => {
   logger.info('extracting', { url })
 
   return xray(url, 'body', {
@@ -41,26 +64,49 @@ const extractFromMoviePage = ({ url }) => {
         time: '.h4',
       },
     ]),
-  }).then((movie) => {
+  }).then((movie: LiffMovie) => {
     if (!hasEnglishSubtitles(movie)) return []
 
     const format = 'cccc d MMMM H:mm'
 
     const date = movie.firstScreening.date
-    const time = movie.firstScreening.time.match(/[\d:]*/)[0] // 17:00 - 18:35 \r\n\r\n-\r\n\r\n'
+    const time = movie.firstScreening.time.match(/[\d:]*/)?.[0]
+    if (!time) {
+      throw new Error(`Could not parse screening time for ${url}`)
+    }
+
+    const firstScreening = DateTime.fromFormat(`${date} ${time}`, format)
+      .toUTC()
+      .toISO()
+    if (!firstScreening) {
+      throw new Error(`Could not parse screening date for ${url}`)
+    }
 
     const screenings = [
-      DateTime.fromFormat(`${date} ${time}`, format).toUTC().toISO(),
+      firstScreening,
       ...movie.restScreenings.map((screening) => {
-        const time = screening.time.match(/[\d:]*/)[0] // 17:00 - 18:35 \r\n\r\n-\r\n\r\n'
+        const time = screening.time.match(/[\d:]*/)?.[0]
+        if (!time) {
+          throw new Error(`Could not parse screening time for ${url}`)
+        }
 
-        const dayIndex = screening.date.match(/\d+/).index // 'Thursday8 November'
+        const dayIndex = screening.date.match(/\d+/)?.index
+        if (dayIndex === undefined) {
+          throw new Error(`Could not parse screening date for ${url}`)
+        }
         const date = [
           screening.date.slice(0, dayIndex),
           screening.date.slice(dayIndex),
         ].join(' ')
 
-        return DateTime.fromFormat(`${date} ${time}`, format).toUTC().toISO()
+        const parsed = DateTime.fromFormat(`${date} ${time}`, format)
+          .toUTC()
+          .toISO()
+        if (!parsed) {
+          throw new Error(`Could not parse screening date for ${url}`)
+        }
+
+        return parsed
       }),
     ]
 
@@ -80,7 +126,9 @@ const extractFromMainPage = () => {
       title: 'a',
     },
   ])
-    .then((results) => Promise.all(results.map(extractFromMoviePage)))
+    .then((results: LiffListing[]) =>
+      Promise.all(results.map(extractFromMoviePage)),
+    )
     .then((results) => results.flat())
 }
 

--- a/cloud/scrapers/lumiere.ts
+++ b/cloud/scrapers/lumiere.ts
@@ -16,17 +16,18 @@ const logger = parentLogger.createChild({
   },
 })
 
-const trim = (value) => (typeof value === 'string' ? value.trim() : value)
+const trim = (value: unknown) =>
+  typeof value === 'string' ? value.trim() : value
 
-const cleanTitle = (value) =>
+const cleanTitle = (value: unknown) =>
   typeof value === 'string'
     ? titleCase(value.replace(/ - Engels ondertiteld/g, ''))
     : value
 
-const toLowerCase = (value) =>
+const toLowerCase = (value: unknown) =>
   typeof value === 'string' ? value.toLowerCase() : value
 
-const replaceNoBreakSpace = (value) =>
+const replaceNoBreakSpace = (value: unknown) =>
   typeof value === 'string' ? value.replace(/\u00a0/g, ' ') : value
 
 const xray = Xray({

--- a/cloud/scrapers/melkweg.ts
+++ b/cloud/scrapers/melkweg.ts
@@ -16,15 +16,45 @@ const logger = parentLogger.createChild({
 
 const xray = Xray({
   filters: {
-    trimColon: (value) =>
+    trimColon: (value: unknown) =>
       typeof value === 'string' ? value.replace(/:$/, '') : value,
   },
 })
   .concurrency(10)
   .throttle(10, 300)
 
+type MelkwegMetadataItem = {
+  key: string
+  value: string
+}
+
+type MelkwegEvent = {
+  attributes: {
+    profile: string
+    name: string
+    url: string
+    startDate: string
+  }
+}
+
+type MelkwegNextData = {
+  props: {
+    pageProps: {
+      pageData: {
+        attributes: {
+          content: {
+            attributes: {
+              initialEvents: MelkwegEvent[]
+            }
+          }[]
+        }
+      }
+    }
+  }
+}
+
 const extractFromMoviePage = async (screening: Screening) => {
-  const data = await xray(
+  const data = (await xray(
     screening.url,
     '[class^="styles_movie-meta-data__list-item"]',
     [
@@ -33,12 +63,15 @@ const extractFromMoviePage = async (screening: Screening) => {
         value: 'dd',
       },
     ],
-  )
+  )) as MelkwegMetadataItem[]
 
-  const metadata = data.reduce((acc, { key, value }) => {
-    acc[key] = value
-    return acc
-  }, {})
+  const metadata = data.reduce<Record<string, string>>(
+    (acc, { key, value }) => {
+      acc[key] = value
+      return acc
+    },
+    {},
+  )
 
   const hasEnglishSubtitles = metadata['Subtitles'] === 'EN'
 
@@ -56,12 +89,12 @@ const cleanTitle = (title: string) => {
 const extractFromMainPage = async () => {
   const url = 'https://www.melkweg.nl/en/agenda/'
 
-  const data = JSON.parse(await xray(url, '#__NEXT_DATA__'))
+  const data = JSON.parse(await xray(url, '#__NEXT_DATA__')) as MelkwegNextData
   const events =
     data.props.pageProps.pageData.attributes.content[0].attributes.initialEvents
 
   const unfilteredScreenings = events
-    .filter((event) => event.attributes.profile === 'Film') // only movies
+    .filter((event: MelkwegEvent) => event.attributes.profile === 'Film') // only movies
     .map((event): Screening => {
       return {
         title: cleanTitle(event.attributes.name),
@@ -77,7 +110,7 @@ const extractFromMainPage = async () => {
   // the __NEXT_DATA__ of the page doesn't contain subtitle information, so we need to filter it out
   const screenings = (
     await Promise.all(unfilteredScreenings.map(extractFromMoviePage))
-  ).filter((x) => x)
+  ).filter((x): x is Screening => x !== null)
 
   logger.info('screenings', { screenings })
   return screenings

--- a/cloud/scrapers/natlab.ts
+++ b/cloud/scrapers/natlab.ts
@@ -19,7 +19,7 @@ const logger = parentLogger.createChild({
 const xray = Xray({
   filters: {
     trim,
-    normalizeWhitespace: (value) =>
+    normalizeWhitespace: (value: unknown) =>
       typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
   },
 })
@@ -29,6 +29,19 @@ const xray = Xray({
 type XRayFromMainPage = {
   url: string
   title: string
+}
+
+type NatlabMoviePage = {
+  title: string
+  screenings: {
+    date: string
+    times: string[]
+  }[]
+  metadata: {
+    key: string[]
+    value: string[]
+  }
+  genres: string[]
 }
 
 const cleanTitle = (title: string) =>
@@ -43,7 +56,7 @@ const extractFromMoviePage = async ({
   url,
   title,
 }: XRayFromMainPage): Promise<Screening[]> => {
-  const scrapeResult = await xray(url, {
+  const scrapeResult = (await xray(url, {
     title: 'h1 | normalizeWhitespace | trim',
     screenings: xray('.subshow', [
       {
@@ -56,7 +69,7 @@ const extractFromMoviePage = async ({
       value: ['dd | normalizeWhitespace | trim'],
     }),
     genres: ['.meta .genres li | normalizeWhitespace | trim'],
-  })
+  })) as NatlabMoviePage
 
   logger.info('movie page', { scrapeResult })
 
@@ -84,9 +97,10 @@ const extractFromMoviePage = async ({
   logger.info('screenings', { screenings: scrapeResult.screenings })
 
   const screenings: Screening[] = scrapeResult.screenings.flatMap(
-    (screening) => {
+    (screening: NatlabMoviePage['screenings'][number]) => {
       return screening.times.map((time: string) => {
-        const [dayOfWeek, day, monthString] = screening.date.split(/\s+/)
+        const [_dayOfWeek, dayString, monthString] = screening.date.split(/\s+/)
+        const day = Number(dayString)
 
         const month = shortMonthToNumberDutch(monthString)
         const [hour, minute] = splitTime(time)

--- a/cloud/scrapers/rialto.ts
+++ b/cloud/scrapers/rialto.ts
@@ -58,9 +58,11 @@ const extractFromMoviePage = async ({
 }) => {
   // url example 'https://rialtofilm.nl/en/films/1519/a-hundred-flowers-expat-cinema'
   const regex = /\/films\/(?<movieId>\d+)\//
-  const {
-    groups: { movieId },
-  } = url.match(regex)
+  const movieMatch = url.match(regex)
+  const movieId = movieMatch?.groups?.movieId
+  if (!movieId) {
+    throw new Error(`Could not extract Rialto movie id from url: ${url}`)
+  }
 
   const data: RialtoFilmFeedResult = await got(
     `https://rialtofilm.nl/feed/en/film/${movieId}`,

--- a/cloud/scrapers/sliekerfilm.ts
+++ b/cloud/scrapers/sliekerfilm.ts
@@ -108,7 +108,7 @@ const extractFromMoviePage = async ({
           value: 'strong | normalizeWhitespace | trim',
         },
       ]),
-    }) as Promise<MovieDetailPage>,
+    }) as unknown as Promise<MovieDetailPage>,
   ])
 
   logger.info('movie page', { id, link, movie, detailPage })

--- a/cloud/types/x-ray-crawler.d.ts
+++ b/cloud/types/x-ray-crawler.d.ts
@@ -1,0 +1,50 @@
+declare module 'x-ray-crawler' {
+  export type DriverContext = {
+    url: string
+    body?: unknown
+  }
+
+  export type DriverCallback = (error: unknown, result: unknown) => void
+
+  export type Driver = (
+    context: DriverContext,
+    callback: DriverCallback,
+  ) => void | Promise<void>
+
+  export type RequestHook = (request: unknown) => void
+  export type ResponseHook = (response: unknown) => void
+  export type RandomDelay = () => number
+
+  export interface InstanceInvocation {
+    (callback: DriverCallback): void
+    (source: string, callback: DriverCallback): void
+    abort(arg: unknown): this
+    paginate(selector: unknown): this
+    limit(n: number): this
+    stream(): NodeJS.ReadStream
+    then<U>(fn?: (value: unknown) => U | PromiseLike<U>): Promise<U>
+    write(path?: string): (err: NodeJS.ErrnoException) => void
+  }
+
+  export interface Instance {
+    (url: string, callback: DriverCallback): void
+    driver(): Driver
+    driver(driver: Driver): this
+    throttle(): number
+    throttle(requests: string | number, rate: string | number): this
+    delay(): RandomDelay
+    delay(from: string | number, to?: string | number): this
+    timeout(): number
+    timeout(n: string | number): this
+    concurrency(): number
+    concurrency(n: number): this
+    request(): RequestHook
+    request(fn: RequestHook): this
+    response(): ResponseHook
+    response(fn: ResponseHook): this
+    limit(): number
+    limit(n: number): this
+  }
+
+  export default function XRayCrawler(driver?: Driver): Instance
+}

--- a/cloud/xRayPuppeteer.ts
+++ b/cloud/xRayPuppeteer.ts
@@ -1,11 +1,12 @@
 import { Logger } from '@aws-lambda-powertools/logger'
 import { WaitForOptions } from 'puppeteer-core'
-import { Driver } from 'x-ray-crawler'
+import { type Driver, type DriverContext } from 'x-ray-crawler'
+import type { Page } from 'puppeteer-core'
 
 import { getBrowser } from './browser'
 
 type XRayPuppeteerOptions = {
-  interactWithPage?: (page: any, ctx: any) => Promise<void>
+  interactWithPage?: (page: Page, ctx: DriverContext) => Promise<void>
   logger?: Logger
   waitForOptions?: WaitForOptions
 }
@@ -15,13 +16,13 @@ const xRayPuppeteer = ({
   logger,
   waitForOptions,
 }: XRayPuppeteerOptions = {}): Driver => {
-  return async (ctx, done) => {
+  return async (ctx: DriverContext, done) => {
     try {
       const browser = await getBrowser({ logger })
 
       logger?.info('opening page', { url: ctx.url })
       let page = await browser.newPage()
-      await page.goto(ctx.url, waitForOptions)
+      await page.goto(String(ctx.url), waitForOptions)
 
       if (interactWithPage) {
         await interactWithPage(page, ctx)


### PR DESCRIPTION
Make the cloud build treat type-check as a blocking gate and fix the branch-local type errors around the cloud entrypoints.

Validation:
- `pnpm --dir cloud exec prettier --check bin/backend.ts handler.ts notifySlack.ts playground.ts scrapers.ts browser.ts`
- branch-local typecheck diagnostics for the touched cloud files are clear