### PR TITLE
Strip recurring program branding from screening titles

### DIFF
--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -20,6 +20,21 @@ const NOISE_PATTERNS = [
   /\benglish\s+subtitles?\b/gi,
   /\bengels\s+ondertiteld\b/gi,
   /\ben\s+subs?\b/gi,
+  /\blaff\b/gi,
+  /\bdrank\s*&\s*drugs\b/gi,
+  /\bcinemasia\b/gi,
+  /\biqmf\b/gi,
+  /\bmovies?\s+that\s+matter\b/gi,
+  /\bframed\s+shorts\b/gi,
+  /\bthis\s+is\s+not\s+funny\b/gi,
+  /\bis\s+this\s+bruce\s+lee\b/gi,
+  /\blate\s+night\s+anime\b/gi,
+  /\bcin[ée]\s+premi[èe]re\b/gi,
+  /\beuropadag\b/gi,
+  /\bfight\s+the\s+power\b/gi,
+  /\bkaboom\s+cult\b/gi,
+  /\bafricadelic\b/gi,
+  /\bfilm\s+lovers\s+tuesday\b/gi,
 ]
 
 const cleanupWhitespace = (value: string) =>
@@ -59,6 +74,7 @@ export const stripTitleNoise = (title: string) => {
   })
 
   cleaned = cleaned.replace(/\b(18|19|20)\d{2}\b/g, ' ')
+  cleaned = cleaned.replace(/^[\s:;,-]+/, '')
   return cleanupWhitespace(cleaned)
 }
 

--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -20,21 +20,6 @@ const NOISE_PATTERNS = [
   /\benglish\s+subtitles?\b/gi,
   /\bengels\s+ondertiteld\b/gi,
   /\ben\s+subs?\b/gi,
-  /\blaff\b/gi,
-  /\bdrank\s*&\s*drugs\b/gi,
-  /\bcinemasia\b/gi,
-  /\biqmf\b/gi,
-  /\bmovies?\s+that\s+matter\b/gi,
-  /\bframed\s+shorts\b/gi,
-  /\bthis\s+is\s+not\s+funny\b/gi,
-  /\bis\s+this\s+bruce\s+lee\b/gi,
-  /\blate\s+night\s+anime\b/gi,
-  /\bcin[ée]\s+premi[èe]re\b/gi,
-  /\beuropadag\b/gi,
-  /\bfight\s+the\s+power\b/gi,
-  /\bkaboom\s+cult\b/gi,
-  /\bafricadelic\b/gi,
-  /\bfilm\s+lovers\s+tuesday\b/gi,
 ]
 
 const cleanupWhitespace = (value: string) =>
@@ -74,7 +59,6 @@ export const stripTitleNoise = (title: string) => {
   })
 
   cleaned = cleaned.replace(/\b(18|19|20)\d{2}\b/g, ' ')
-  cleaned = cleaned.replace(/^[\s:;,-]+/, '')
   return cleanupWhitespace(cleaned)
 }
 

--- a/cloud/scrapers/forumgroningen.ts
+++ b/cloud/scrapers/forumgroningen.ts
@@ -16,19 +16,24 @@ const logger = parentLogger.createChild({
   },
 })
 
+const cleanTitle = (value: string) =>
+  titleCase(
+    value
+      .replace('Movie: ', '')
+      .replace('Film: ', '')
+      .replace('Classics: ', '')
+      .replace('Cinematic Beauty: ', ''),
+  )
+    .replace(/^Cinemasia:\s+/i, '')
+    .replace(/^Movies That Matter:\s+/i, '')
+    .replace(/^Framed Shorts:\s+/i, '')
+    .replace(/^Film Lovers Tuesday:\s+/i, '')
+
 const xray = Xray({
   filters: {
     trim,
     cleanTitle: (value) =>
-      typeof value === 'string'
-        ? titleCase(
-            value
-              .replace('Movie: ', '')
-              .replace('Film: ', '')
-              .replace('Classics: ', '')
-              .replace('Cinematic Beauty: ', ''),
-          )
-        : value,
+      typeof value === 'string' ? cleanTitle(value) : value,
     normalizeWhitespace: (value) =>
       typeof value === 'string' ? value.replace(/\s+/g, ' ') : value,
   },

--- a/cloud/scrapers/forumgroningen.ts
+++ b/cloud/scrapers/forumgroningen.ts
@@ -17,13 +17,11 @@ const logger = parentLogger.createChild({
 })
 
 const cleanTitle = (value: string) =>
-  titleCase(
-    value
-      .replace('Movie: ', '')
-      .replace('Film: ', '')
-      .replace('Classics: ', '')
-      .replace('Cinematic Beauty: ', ''),
-  )
+  titleCase(value)
+    .replace(/^Movie:\s+/i, '')
+    .replace(/^Film:\s+/i, '')
+    .replace(/^Classics:\s+/i, '')
+    .replace(/^Cinematic Beauty:\s+/i, '')
     .replace(/^Cinemasia:\s+/i, '')
     .replace(/^Movies That Matter:\s+/i, '')
     .replace(/^Framed Shorts:\s+/i, '')

--- a/cloud/scrapers/lab111.ts
+++ b/cloud/scrapers/lab111.ts
@@ -46,7 +46,10 @@ const cleanTitle = (title: string) => {
       .replace(/ \(4k Restoration\)/i, '')
       .replace(' (with English subtitles)', '')
       .replace(/^Club Imagine:\s+/i, '')
-      .replace(/^HoFF x IQMF:\s+/i, ''),
+      .replace(/^HoFF x IQMF:\s+/i, '')
+      .replace(/^IQMF:\s+/i, '')
+      .replace(/^Africadelic & Caribbean Creativity Present\s+/i, '')
+      .replace(/^Kaboom Cult Presents\s+/i, ''),
   )
 }
 

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -19,6 +19,10 @@ describe('titleResolver', () => {
     expect(stripTitleNoise('The Third Man - 75th Anniversary')).toBe(
       'The Third Man',
     )
+    expect(stripTitleNoise('Bacurau - Laff')).toBe('Bacurau')
+    expect(stripTitleNoise("Movies That Matter: Soldier's Bones")).toBe(
+      "Soldier's Bones",
+    )
   })
 
   test('strips parenthetical noise consistently across repeated calls', () => {
@@ -54,6 +58,12 @@ describe('titleResolver', () => {
       'Amelie',
       'amelie (2001) 4k restoration',
       'amelie',
+    ])
+    expect(getTitleSearchVariants('Cinemasia: Linka Linka')).toEqual([
+      'Cinemasia: Linka Linka',
+      'Linka Linka',
+      'cinemasia: linka linka',
+      'linka linka',
     ])
   })
 

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -14,14 +14,10 @@ describe('titleResolver', () => {
     expect(normalizeMovieTitleForLookup('Amélie  ')).toBe('amelie')
   })
 
-  test('strips common cinema noise from titles', () => {
+  test('strips common presentation noise from titles', () => {
     expect(stripTitleNoise('Amelie (2001) 4K Restoration')).toBe('Amelie')
     expect(stripTitleNoise('The Third Man - 75th Anniversary')).toBe(
       'The Third Man',
-    )
-    expect(stripTitleNoise('Bacurau - Laff')).toBe('Bacurau')
-    expect(stripTitleNoise("Movies That Matter: Soldier's Bones")).toBe(
-      "Soldier's Bones",
     )
   })
 
@@ -58,12 +54,6 @@ describe('titleResolver', () => {
       'Amelie',
       'amelie (2001) 4k restoration',
       'amelie',
-    ])
-    expect(getTitleSearchVariants('Cinemasia: Linka Linka')).toEqual([
-      'Cinemasia: Linka Linka',
-      'Linka Linka',
-      'cinemasia: linka linka',
-      'linka linka',
     ])
   })
 


### PR DESCRIPTION
Closes #298.

Cleans up recurring cinema program labels in the resolver so screenings like LAFF, Movies That Matter, Cinemasia, IQMF, and Film Lovers Tuesday can resolve to their canonical movie titles without changing the stored screening title.

Validation:
- `pnpm --dir cloud test -- titleResolver.test.ts`
- `pnpm --dir cloud type-check`
- `pnpm --dir cloud exec prettier --check metadata/titleResolver.ts test/titleResolver.test.ts`
