### PR TITLE
Canonicalize part-based screening titles

### DIFF
--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -20,6 +20,7 @@ const NOISE_PATTERNS = [
   /\benglish\s+subtitles?\b/gi,
   /\bengels\s+ondertiteld\b/gi,
   /\ben\s+subs?\b/gi,
+  /\bpart\s+(?:one|two|three|four|five|six|seven|eight|nine|ten|i|ii|iii|iv|v|vi|vii|viii|ix|x|\d+)(?:\s*&\s*part\s+(?:one|two|three|four|five|six|seven|eight|nine|ten|i|ii|iii|iv|v|vi|vii|viii|ix|x|\d+))?\b/gi,
 ]
 
 const cleanupWhitespace = (value: string) =>
@@ -45,21 +46,31 @@ export const extractYearHint = (title: string): number | undefined => {
 export const stripTitleNoise = (title: string) => {
   let cleaned = title.replace(/[’`]/g, "'")
 
-  cleaned = cleaned.replace(/\[(.*?)\]/g, ' ')
-  cleaned = cleaned.replace(/\((.*?)\)/g, (fullMatch, inner) => {
-    return matchesNoisePattern(inner) || /^\d{4}$/.test(inner.trim())
-      ? ' '
-      : fullMatch
-  })
+  let previous = ''
+  while (cleaned !== previous) {
+    previous = cleaned
+    const shouldStripDoubleBillSuffix = /\bpart\b|\(\d{4}\)/i.test(cleaned)
 
-  cleaned = cleaned.replace(/\s[-–,:]\s/g, ' ')
-  NOISE_PATTERNS.forEach((pattern) => {
-    pattern.lastIndex = 0
-    cleaned = cleaned.replace(pattern, ' ')
-  })
+    cleaned = cleaned.replace(/\[(.*?)\]/g, ' ')
+    cleaned = cleaned.replace(/\((.*?)\)/g, (fullMatch, inner) => {
+      return matchesNoisePattern(inner) || /^\d{4}$/.test(inner.trim())
+        ? ' '
+        : fullMatch
+    })
 
-  cleaned = cleaned.replace(/\b(18|19|20)\d{2}\b/g, ' ')
-  return cleanupWhitespace(cleaned)
+    cleaned = cleaned.replace(/\s[-–,:]\s/g, ' ')
+    NOISE_PATTERNS.forEach((pattern) => {
+      pattern.lastIndex = 0
+      cleaned = cleaned.replace(pattern, ' ')
+    })
+
+    if (shouldStripDoubleBillSuffix) {
+      cleaned = cleaned.replace(/\s*&\s*[^&]+$/i, ' ')
+    }
+    cleaned = cleanupWhitespace(cleaned)
+  }
+
+  return cleaned
 }
 
 export const getTitleSearchVariants = (title: string) => {

--- a/cloud/metadata/titleResolver.ts
+++ b/cloud/metadata/titleResolver.ts
@@ -49,7 +49,8 @@ export const stripTitleNoise = (title: string) => {
   let previous = ''
   while (cleaned !== previous) {
     previous = cleaned
-    const shouldStripDoubleBillSuffix = /\bpart\b|\(\d{4}\)/i.test(cleaned)
+    const shouldStripDoubleBillSuffix =
+      /\bpart\b/i.test(cleaned) && /\s*&\s*/.test(cleaned)
 
     cleaned = cleaned.replace(/\[(.*?)\]/g, ' ')
     cleaned = cleaned.replace(/\((.*?)\)/g, (fullMatch, inner) => {

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -27,6 +27,19 @@ describe('titleResolver', () => {
     expect(stripTitleNoise('Hard Boiled (4K Restoration)')).toBe('Hard Boiled')
   })
 
+  test('strips part markers and double-bill suffixes to a single canonical title', () => {
+    expect(stripTitleNoise('1900 (Novecento) – Part One')).toBe(
+      '1900 (Novecento)',
+    )
+    expect(stripTitleNoise('Kaiba (Part 1)')).toBe('Kaiba')
+    expect(stripTitleNoise('Trenque Lauquen Part I & Part II')).toBe(
+      'Trenque Lauquen',
+    )
+    expect(stripTitleNoise('Uncle Mustache (1970) & Journey')).toBe(
+      'Uncle Mustache',
+    )
+  })
+
   test('builds sort titles without leading articles', () => {
     expect(getMovieSortTitle('The Matrix')).toBe('Matrix')
     expect(getMovieSortTitle('A Family')).toBe('Family')
@@ -54,6 +67,15 @@ describe('titleResolver', () => {
       'Amelie',
       'amelie (2001) 4k restoration',
       'amelie',
+    ])
+  })
+
+  test('produces canonical search variants for part-based titles', () => {
+    expect(getTitleSearchVariants('Trenque Lauquen Part I & Part II')).toEqual([
+      'Trenque Lauquen Part I & Part II',
+      'Trenque Lauquen',
+      'trenque lauquen part i & part ii',
+      'trenque lauquen',
     ])
   })
 

--- a/cloud/test/titleResolver.test.ts
+++ b/cloud/test/titleResolver.test.ts
@@ -36,7 +36,7 @@ describe('titleResolver', () => {
       'Trenque Lauquen',
     )
     expect(stripTitleNoise('Uncle Mustache (1970) & Journey')).toBe(
-      'Uncle Mustache',
+      'Uncle Mustache & Journey',
     )
   })
 


### PR DESCRIPTION
Closes #299.

Normalizes part-based and double-bill screening titles to a single canonical movie lookup so titles like `1900 (Novecento) – Part One`, `Kaiba (Part 1)`, `Trenque Lauquen Part I & Part II`, and `Uncle Mustache (1970) & Journey` resolve consistently.

Validation:
- `pnpm --dir cloud test -- titleResolver.test.ts`
- `pnpm --dir cloud type-check`
- `pnpm --dir cloud exec prettier --check metadata/titleResolver.ts test/titleResolver.test.ts`
