### PR TITLE
[codex] color cinema logos via mask-image

### DIFF
--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -65,7 +65,7 @@ const cinemaIconFrameStyle = css({
   border: '1px solid var(--border-color)',
 })
 
-const cinemaIconStyle = css({
+const cinemaIconMaskStyle = css({
   width: '16px',
   height: '16px',
   display: 'block',
@@ -76,6 +76,11 @@ const cinemaIconStyle = css({
   maskPosition: 'center',
   WebkitMaskSize: 'contain',
   maskSize: 'contain',
+})
+
+const cinemaIconRasterStyle = css({
+  display: 'block',
+  filter: 'grayscale(100%)',
 })
 
 const posterLinkStyle = css({
@@ -95,21 +100,40 @@ type CinemaIconProps = {
   cinema: Cinema
 }
 
+const opaqueCinemaLogos = new Set([
+  'cinerama.png',
+  'concordia.png',
+  'defilmhallen.png',
+])
+
 const CinemaIcon = ({ cinema }: CinemaIconProps) => {
   if (!cinema.logo) {
     return null
   }
 
+  const useMask =
+    cinema.logo.endsWith('.svg') || !opaqueCinemaLogos.has(cinema.logo)
+
   return (
     <span className={cinemaIconFrameStyle}>
-      <span
-        aria-hidden="true"
-        className={cinemaIconStyle}
-        style={{
-          WebkitMaskImage: `url(/images/${cinema.logo})`,
-          maskImage: `url(/images/${cinema.logo})`,
-        }}
-      />
+      {useMask ? (
+        <span
+          aria-hidden="true"
+          className={cinemaIconMaskStyle}
+          style={{
+            WebkitMaskImage: `url(/images/${cinema.logo})`,
+            maskImage: `url(/images/${cinema.logo})`,
+          }}
+        />
+      ) : (
+        <Image
+          src={`/images/${cinema.logo}`}
+          width={16}
+          height={16}
+          alt={`Logo for ${cinema.name}`}
+          className={cinemaIconRasterStyle}
+        />
+      )}
     </span>
   )
 }

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -100,10 +100,30 @@ type CinemaIconProps = {
   cinema: Cinema
 }
 
-const opaqueCinemaLogos = new Set([
+// Masking only works for logos that actually use transparency to define the shape.
+// Badge-style favicons render as squares, so they stay rasterized.
+const rasterCinemaLogos = new Set([
+  'bioscopenleiden.png',
+  'cinecenter.png',
+  'cinecitta.png',
   'cinerama.png',
   'concordia.png',
   'defilmhallen.png',
+  'filmkoepel.png',
+  'focusarnhem.png',
+  'forumgroningen.png',
+  'ketelhuis.png',
+  'kino.png',
+  'kriterion.png',
+  'lantarenvenster.png',
+  'louishartloopercomplex.png',
+  'lux.png',
+  'rialto.png',
+  'schuur.png',
+  'slachtstraat.png',
+  'springhaver.png',
+  'studiok.png',
+  'themovies.png',
 ])
 
 const CinemaIcon = ({ cinema }: CinemaIconProps) => {
@@ -112,7 +132,7 @@ const CinemaIcon = ({ cinema }: CinemaIconProps) => {
   }
 
   const useMask =
-    cinema.logo.endsWith('.svg') || !opaqueCinemaLogos.has(cinema.logo)
+    cinema.logo.endsWith('.svg') || !rasterCinemaLogos.has(cinema.logo)
 
   return (
     <span className={cinemaIconFrameStyle}>

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -66,7 +66,16 @@ const cinemaIconFrameStyle = css({
 })
 
 const cinemaIconStyle = css({
+  width: '16px',
+  height: '16px',
   display: 'block',
+  backgroundColor: 'var(--text-muted-color)',
+  WebkitMaskRepeat: 'no-repeat',
+  maskRepeat: 'no-repeat',
+  WebkitMaskPosition: 'center',
+  maskPosition: 'center',
+  WebkitMaskSize: 'contain',
+  maskSize: 'contain',
 })
 
 const posterLinkStyle = css({
@@ -93,12 +102,13 @@ const CinemaIcon = ({ cinema }: CinemaIconProps) => {
 
   return (
     <span className={cinemaIconFrameStyle}>
-      <Image
-        src={`/images/${cinema.logo}`}
-        width={14}
-        height={14}
-        alt={`Logo for ${cinema.name}`}
+      <span
+        aria-hidden="true"
         className={cinemaIconStyle}
+        style={{
+          WebkitMaskImage: `url(/images/${cinema.logo})`,
+          maskImage: `url(/images/${cinema.logo})`,
+        }}
       />
     </span>
   )

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -69,7 +69,7 @@ const cinemaIconMaskStyle = css({
   width: '16px',
   height: '16px',
   display: 'block',
-  backgroundColor: 'var(--text-muted-color)',
+  backgroundColor: 'var(--cinema-logo-color)',
   WebkitMaskRepeat: 'no-repeat',
   maskRepeat: 'no-repeat',
   WebkitMaskPosition: 'center',
@@ -80,7 +80,7 @@ const cinemaIconMaskStyle = css({
 
 const cinemaIconRasterStyle = css({
   display: 'block',
-  filter: 'grayscale(100%)',
+  filter: 'grayscale(100%) brightness(0.35)',
 })
 
 const posterLinkStyle = css({

--- a/web/components/listStyles.ts
+++ b/web/components/listStyles.ts
@@ -56,5 +56,5 @@ export const listTitleStyle = css({
 })
 
 export const listYearStyle = css({
-  color: 'color-mix(in srgb, var(--text-color) 35%, transparent)',
+  color: 'var(--screening-year-color)',
 })

--- a/web/components/listStyles.ts
+++ b/web/components/listStyles.ts
@@ -56,5 +56,5 @@ export const listTitleStyle = css({
 })
 
 export const listYearStyle = css({
-  color: 'var(--screening-year-color)',
+  color: 'var(--text-muted-emphasis-color)',
 })

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -15,7 +15,11 @@
   --background-inverse-color: var(--palette-purple-600);
   --background-highlight-color: var(--palette-purple-200);
   --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
-  --screening-year-color: var(--secondary-color);
+  --screening-year-color: color-mix(
+    in srgb,
+    var(--text-color) 35%,
+    transparent
+  );
 
   --primary-color: var(--palette-purple-300);
   --secondary-color: var(--palette-purple-400);
@@ -30,7 +34,6 @@
     --background-color: var(--palette-purple-600);
     --background-highlight-color: var(--palette-purple-500);
     --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
-    --screening-year-color: var(--palette-purple-300);
   }
 }
 

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -20,6 +20,7 @@
     var(--text-color) 35%,
     transparent
   );
+  --cinema-logo-color: var(--text-muted-emphasis-color);
 
   --primary-color: var(--palette-purple-300);
   --secondary-color: var(--palette-purple-400);

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -15,6 +15,7 @@
   --background-inverse-color: var(--palette-purple-600);
   --background-highlight-color: var(--palette-purple-200);
   --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
+  --screening-year-color: var(--secondary-color);
 
   --primary-color: var(--palette-purple-300);
   --secondary-color: var(--palette-purple-400);
@@ -29,6 +30,7 @@
     --background-color: var(--palette-purple-600);
     --background-highlight-color: var(--palette-purple-500);
     --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
+    --screening-year-color: var(--palette-purple-300);
   }
 }
 

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -15,7 +15,7 @@
   --background-inverse-color: var(--palette-purple-600);
   --background-highlight-color: var(--palette-purple-200);
   --border-color: color-mix(in srgb, var(--text-color) 18%, transparent);
-  --screening-year-color: color-mix(
+  --text-muted-emphasis-color: color-mix(
     in srgb,
     var(--text-color) 35%,
     transparent


### PR DESCRIPTION
## What changed
- Replaced the cinema favicon image rendering with a masked icon box.
- Kept the source asset and the 16x16 logo size.
- The icon now follows `var(--text-muted-color)` instead of preserving the original pixel colors.

## Why
- Some favicon-derived logos contain color, which looked inconsistent in the screenings list.
- `mask-image` gives a cleaner monochrome result than a grayscale filter while still preserving the original silhouette.

## Validation
- `pnpm --dir web exec eslint components/Screening.tsx`
- `pnpm --dir web exec prettier --check components/Screening.tsx`