### PR TITLE
[codex] make screening rows fully clickable

### DIFF
--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -31,12 +31,11 @@ const timeStyle = css({
   gridRow: '1 / span 2',
   alignSelf: 'start',
   paddingTop: '4px',
+  pointerEvents: 'none',
 })
 
 const contentStyle = css({
-  position: 'relative',
-  zIndex: '1',
-  pointerEvents: 'none',
+  display: 'contents',
 })
 
 const cinemaInfoStyle = css({
@@ -47,6 +46,7 @@ const cinemaInfoStyle = css({
   color: 'var(--text-muted-color)',
   display: 'flex',
   alignItems: 'center',
+  pointerEvents: 'none',
 })
 
 const cinemaIconFrameStyle = css({
@@ -150,11 +150,11 @@ export const ScreeningRow = ({
           aria-label={`Open screening for ${title}`}
           className={screeningRowLinkStyle}
         />
-        <div className={`${timeStyle} ${contentStyle}`}>
+        <div className={timeStyle}>
           <Time>{date}</Time>
         </div>
         <div className={contentStyle}>
-          <div className={listTitleStyle}>
+          <div className={listTitleStyle} style={{ pointerEvents: 'none' }}>
             {title}
             {year ? <span className={listYearStyle}> ({year})</span> : null}
           </div>

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -15,14 +15,10 @@ import {
   listYearStyle,
 } from './listStyles'
 
-const aStyle = css({
-  textDecoration: 'none',
-  color: 'var(--text-color)',
-})
-
 const containerStyle = cx(
   listRowBaseStyle,
   css({
+    position: 'relative',
     display: 'grid',
     gridTemplateColumns: '[time] 60px [rest] minmax(0, 1fr) [poster] auto',
     gridTemplateRows: 'auto auto',
@@ -38,7 +34,9 @@ const timeStyle = css({
 })
 
 const contentStyle = css({
-  display: 'contents',
+  position: 'relative',
+  zIndex: '1',
+  pointerEvents: 'none',
 })
 
 const cinemaInfoStyle = css({
@@ -75,9 +73,15 @@ const posterLinkStyle = css({
   display: 'block',
   width: '48px',
   height: '72px',
+  position: 'relative',
+  zIndex: '2',
 })
 
-const screeningLinkStyle = css({
+const screeningRowLinkStyle = css({
+  position: 'absolute',
+  inset: '0',
+  zIndex: '0',
+  display: 'block',
   textDecoration: 'none',
   color: 'var(--text-color)',
 })
@@ -143,14 +147,13 @@ export const ScreeningRow = ({
       <div className={containerStyle}>
         <a
           href={url}
-          className={`${aStyle} ${screeningLinkStyle} ${timeStyle}`}
-        >
+          aria-label={`Open screening for ${title}`}
+          className={screeningRowLinkStyle}
+        />
+        <div className={`${timeStyle} ${contentStyle}`}>
           <Time>{date}</Time>
-        </a>
-        <a
-          href={url}
-          className={`${aStyle} ${screeningLinkStyle} ${contentStyle}`}
-        >
+        </div>
+        <div className={contentStyle}>
           <div className={listTitleStyle}>
             {title}
             {year ? <span className={listYearStyle}> ({year})</span> : null}
@@ -160,7 +163,7 @@ export const ScreeningRow = ({
             {cinema.name}
             {showCity ? <> | {cinema.city.name}</> : null}
           </div>
-        </a>
+        </div>
         {showPoster && posterUrl && movieUrl ? (
           <a href={movieUrl} className={posterLinkStyle}>
             <Image


### PR DESCRIPTION
## What changed
- Added a full-row overlay link so the entire Screening row is clickable.
- Kept the poster link above the overlay when a separate movie destination exists.
- Removed the dead click gaps caused by the previous `display: contents` link layout.

## Why
- Some areas in the row were not clickable because only parts of the grid were wrapped in links.
- The row should behave like a single interactive target while preserving the poster behavior.

## Validation
- `pnpm --dir web exec eslint components/Screening.tsx`
- `pnpm --dir web exec prettier --check components/Screening.tsx`