### PR TITLE
Add Bioscopen Leiden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ web/tsconfig.tsbuildinfo
 backup/
 .env.*
 
-data
 .claude/settings.local.json
 .claude/worktrees/
 output/expatcinema-dev-scrapers.json

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -310,5 +310,12 @@
     "slug": "filmhuis-botanique-filmhuis-breda",
     "city": "breda",
     "url": "https://www.filmhuisbreda.nl/"
+  },
+  {
+    "name": "Bioscopen Leiden",
+    "slug": "bioscopen-leiden",
+    "city": "leiden",
+    "url": "https://bioscopenleiden.nl/",
+    "logo": "bioscopenleiden.png"
   }
 ]

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -304,5 +304,11 @@
     "city": "rotterdam",
     "url": "https://dokhuis.org/",
     "logo": "dokhuis.png"
+  },
+  {
+    "name": "Filmhuis Botanique / Filmhuis Breda",
+    "slug": "filmhuis-botanique-filmhuis-breda",
+    "city": "breda",
+    "url": "https://www.filmhuisbreda.nl/"
   }
 ]

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -310,12 +310,5 @@
     "slug": "filmhuis-botanique-filmhuis-breda",
     "city": "breda",
     "url": "https://www.filmhuisbreda.nl/"
-  },
-  {
-    "name": "Bioscopen Leiden",
-    "slug": "bioscopen-leiden",
-    "city": "leiden",
-    "url": "https://bioscopenleiden.nl/",
-    "logo": "bioscopenleiden.png"
   }
 ]


### PR DESCRIPTION
Adds Bioscopen Leiden to the cinema registry.\n\nThe existing bioscopenleiden scraper already finds the issue example movie HAIKYU!! The Dumpster Battle at https://bioscopenleiden.nl/films/haikyu-the-dumpster-battle/ with English subtitles, so no scraper code change is needed.