### PR TITLE
Align SEO canonical host

### DIFF
--- a/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
@@ -5,6 +5,7 @@ import { App } from '../../../../../../components/App'
 import cinemas from '../../../../../../data/cinema.json'
 import { getCinema } from '../../../../../../utils/getCinema'
 import { getScreenings } from '../../../../../../utils/getScreenings'
+import { getCanonicalUrl } from '../../../../../../utils/siteUrl'
 
 export const generateStaticParams = () =>
   cinemas.map((cinema) => ({
@@ -25,7 +26,7 @@ export async function generateMetadata({
   return {
     title: `${cinemaName}, ${cityName} – Expat Cinema`,
     alternates: {
-      canonical: `https://expatcinema.com/city/${city}/cinema/${cinema}`,
+      canonical: getCanonicalUrl(`/city/${city}/cinema/${cinema}`),
     },
   }
 }

--- a/web/app/(screenings)/city/[city]/page.tsx
+++ b/web/app/(screenings)/city/[city]/page.tsx
@@ -5,6 +5,7 @@ import { App } from '../../../../components/App'
 import cities from '../../../../data/city.json'
 import { getCity } from '../../../../utils/getCity'
 import { getScreenings } from '../../../../utils/getScreenings'
+import { getCanonicalUrl } from '../../../../utils/siteUrl'
 
 export const generateStaticParams = () =>
   cities.map((city) => ({ city: city.slug }))
@@ -19,7 +20,7 @@ export async function generateMetadata({
 
   return {
     title: `${cityName} – Expat Cinema`,
-    alternates: { canonical: `https://expatcinema.com/city/${city}` },
+    alternates: { canonical: getCanonicalUrl(`/city/${city}`) },
   }
 }
 

--- a/web/app/(screenings)/page.tsx
+++ b/web/app/(screenings)/page.tsx
@@ -3,10 +3,11 @@ import { Suspense } from 'react'
 
 import { App } from '../../components/App'
 import { getScreenings } from '../../utils/getScreenings'
+import { getCanonicalUrl } from '../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'Expat Cinema',
-  alternates: { canonical: 'https://expatcinema.com' },
+  alternates: { canonical: getCanonicalUrl() },
 }
 
 export default async function Home() {

--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -2,11 +2,12 @@ import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
 import { About } from '../../components/About'
+import { getCanonicalUrl } from '../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'About – Expat Cinema',
   description: 'Foreign movies with English subtitles',
-  alternates: { canonical: 'https://expatcinema.com/about' },
+  alternates: { canonical: getCanonicalUrl('/about') },
 }
 
 export default function AboutPage() {

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,11 +4,13 @@ import React from 'react'
 
 import '../styles/globals.css'
 import { bodyFont } from '../utils/theme'
+import { siteUrl } from '../utils/siteUrl'
 import { GoogleAnalytics } from './GoogleAnalytics'
 
 Settings.defaultZone = 'Europe/Amsterdam'
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   description: 'Foreign movies with English subtitles',
   openGraph: {
     type: 'website',

--- a/web/app/movie/page.tsx
+++ b/web/app/movie/page.tsx
@@ -5,10 +5,11 @@ import { MoviesOverview } from '../../components/MoviesOverview'
 import { NavigationBar } from '../../components/NavigationBar'
 import { Layout } from '../../components/Layout'
 import { getMovies } from '../../utils/getMovies'
+import { getCanonicalUrl } from '../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'Movies – Expat Cinema',
-  alternates: { canonical: 'https://expatcinema.com/movie' },
+  alternates: { canonical: getCanonicalUrl('/movie') },
 }
 
 export default async function MoviesPage() {

--- a/web/app/movie/unmatched/page.tsx
+++ b/web/app/movie/unmatched/page.tsx
@@ -5,10 +5,11 @@ import { NavigationBar } from '../../../components/NavigationBar'
 import { Layout } from '../../../components/Layout'
 import { UnmatchedMoviesOverview } from '../../../components/UnmatchedMoviesOverview'
 import { getScreenings } from '../../../utils/getScreenings'
+import { getCanonicalUrl } from '../../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'Unmatched movies – Expat Cinema',
-  alternates: { canonical: 'https://expatcinema.com/movie/unmatched' },
+  alternates: { canonical: getCanonicalUrl('/movie/unmatched') },
   robots: {
     index: false,
     follow: false,

--- a/web/app/statistics/page.tsx
+++ b/web/app/statistics/page.tsx
@@ -4,11 +4,12 @@ import React, { Suspense } from 'react'
 import { Layout } from '../../components/Layout'
 import { NavigationBar } from '../../components/NavigationBar'
 import { PageTitle } from '../../components/PageTitle'
+import { getCanonicalUrl } from '../../utils/siteUrl'
 import { StatisticsClient } from './StatisticsClient'
 
 export const metadata: Metadata = {
   title: 'Statistics – Expat Cinema',
-  alternates: { canonical: 'https://expatcinema.com/statistics' },
+  alternates: { canonical: getCanonicalUrl('/statistics') },
 }
 
 export default async function StatisticsPage() {

--- a/web/next-sitemap.config.js
+++ b/web/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: 'https://expatcinema.com',
+  siteUrl: 'https://www.expatcinema.com',
   generateRobotsTxt: true,
   outDir: 'public',
   // ...other options

--- a/web/utils/getMoviePageData.ts
+++ b/web/utils/getMoviePageData.ts
@@ -5,6 +5,7 @@ import { getCity } from './getCity'
 import { getMovieReleaseYear, getMovieSlug, Movie } from './getMovies'
 import { Screening } from './getScreenings'
 import { getMoviePagePath } from './getMoviePagePath'
+import { getCanonicalUrl } from './siteUrl'
 
 const getMovieIdScreeningCounts = (screenings: Screening[]) =>
   screenings.reduce<Record<string, number>>((counts, screening) => {
@@ -150,11 +151,7 @@ export const buildMoviePageMetadata = (
       ? `${title} in ${locationLabel} – Expat Cinema`
       : `${title} – Expat Cinema`,
     alternates: {
-      canonical: `https://expatcinema.com${getMoviePagePath(
-        movieSlug,
-        city,
-        cinema,
-      )}`,
+      canonical: getCanonicalUrl(getMoviePagePath(movieSlug, city, cinema)),
     },
   }
 }

--- a/web/utils/siteUrl.ts
+++ b/web/utils/siteUrl.ts
@@ -1,0 +1,3 @@
+export const siteUrl = 'https://www.expatcinema.com'
+
+export const getCanonicalUrl = (path = '') => `${siteUrl}${path}`


### PR DESCRIPTION
## Summary
- Introduce a shared `siteUrl` / `getCanonicalUrl` helper for app metadata.
- Update route canonical URLs to use `https://www.expatcinema.com`.
- Update `next-sitemap` to generate sitemap and robots URLs with the same `www` host.

Closes #331.

## Validation
- `pnpm --dir web exec eslint 'app/(screenings)/city/[city]/cinema/[cinema]/page.tsx' 'app/(screenings)/city/[city]/page.tsx' 'app/(screenings)/page.tsx' app/about/page.tsx app/layout.tsx app/movie/page.tsx app/movie/unmatched/page.tsx app/statistics/page.tsx utils/getMoviePageData.ts utils/siteUrl.ts next-sitemap.config.js`
- `pnpm --dir web exec tsc --noEmit --pretty false`
- `pnpm --dir web exec next build` with network access
- `pnpm --dir web exec next-sitemap`