### PR TITLE
Deploy generated sitemap files

### DIFF
--- a/web/next-sitemap.config.js
+++ b/web/next-sitemap.config.js
@@ -2,6 +2,6 @@
 module.exports = {
   siteUrl: 'https://expatcinema.com',
   generateRobotsTxt: true,
-  outDir: 'public',
+  outDir: 'out',
   // ...other options
 }


### PR DESCRIPTION
## Summary
- Change `next-sitemap` output from `web/public` to `web/out`.
- This matches the GitHub Pages workflow artifact path, so generated `sitemap.xml`, `sitemap-0.xml`, and `robots.txt` are included in the deployed artifact.

Closes #332.

## Validation
- `pnpm --dir web exec next build && pnpm --dir web exec next-sitemap`
- Verified `web/out/sitemap.xml`, `web/out/sitemap-0.xml`, and `web/out/robots.txt` are present after generation.
- `pnpm --dir web exec eslint next-sitemap.config.js`

## Note
This branch starts from `main`, so generated URLs still show the current apex host. PR #340 updates the sitemap host to `https://www.expatcinema.com`; after both PRs merge, the deployed sitemap files will be generated into `web/out` with the canonical `www` host.