### PR TITLE
Improve SEO metadata

### DIFF
--- a/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
@@ -4,7 +4,9 @@ import { Suspense } from 'react'
 import { App } from '../../../../../../components/App'
 import cinemas from '../../../../../../data/cinema.json'
 import { getCinema } from '../../../../../../utils/getCinema'
+import { getCity } from '../../../../../../utils/getCity'
 import { getScreenings } from '../../../../../../utils/getScreenings'
+import { buildCinemaDescription } from '../../../../../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../../../../../utils/siteUrl'
 
 export const generateStaticParams = () =>
@@ -21,10 +23,11 @@ export async function generateMetadata({
   const { city, cinema } = await params
   const cinemaData = getCinema(cinema)
   const cinemaName = cinemaData?.name ?? cinema
-  const cityName = cinemaData?.city ?? city
+  const cityName = getCity(cinemaData?.city ?? city)?.name ?? city
 
   return {
-    title: `${cinemaName}, ${cityName} – Expat Cinema`,
+    title: `English-Subtitled Movies at ${cinemaName}, ${cityName} – Expat Cinema`,
+    description: buildCinemaDescription(cinemaName, cityName),
     alternates: {
       canonical: getCanonicalUrl(`/city/${city}/cinema/${cinema}`),
     },

--- a/web/app/(screenings)/city/[city]/page.tsx
+++ b/web/app/(screenings)/city/[city]/page.tsx
@@ -5,6 +5,7 @@ import { App } from '../../../../components/App'
 import cities from '../../../../data/city.json'
 import { getCity } from '../../../../utils/getCity'
 import { getScreenings } from '../../../../utils/getScreenings'
+import { buildCityDescription } from '../../../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../../../utils/siteUrl'
 
 export const generateStaticParams = () =>
@@ -17,9 +18,13 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { city } = await params
   const cityName = getCity(city)?.name ?? city
+  const screenings = (await getScreenings()).filter(
+    (screening) => screening.cinema.city.slug === city,
+  )
 
   return {
-    title: `${cityName} – Expat Cinema`,
+    title: `English-Subtitled Movies in ${cityName} – Expat Cinema`,
+    description: buildCityDescription(cityName, screenings),
     alternates: { canonical: getCanonicalUrl(`/city/${city}`) },
   }
 }

--- a/web/app/(screenings)/page.tsx
+++ b/web/app/(screenings)/page.tsx
@@ -3,10 +3,12 @@ import { Suspense } from 'react'
 
 import { App } from '../../components/App'
 import { getScreenings } from '../../utils/getScreenings'
+import { defaultDescription } from '../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'Expat Cinema',
+  description: defaultDescription,
   alternates: { canonical: getCanonicalUrl() },
 }
 

--- a/web/app/about/page.tsx
+++ b/web/app/about/page.tsx
@@ -2,11 +2,12 @@ import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
 import { About } from '../../components/About'
+import { defaultDescription } from '../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'About – Expat Cinema',
-  description: 'Foreign movies with English subtitles',
+  description: defaultDescription,
   alternates: { canonical: getCanonicalUrl('/about') },
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -3,6 +3,7 @@ import { Settings } from 'luxon'
 import React from 'react'
 
 import '../styles/globals.css'
+import { defaultDescription } from '../utils/seoMetadata'
 import { bodyFont } from '../utils/theme'
 import { siteUrl } from '../utils/siteUrl'
 import { GoogleAnalytics } from './GoogleAnalytics'
@@ -11,11 +12,11 @@ Settings.defaultZone = 'Europe/Amsterdam'
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  description: 'Foreign movies with English subtitles',
+  description: defaultDescription,
   openGraph: {
     type: 'website',
     siteName: 'Expat Cinema',
-    description: 'Foreign movies with English subtitles',
+    description: defaultDescription,
   },
   twitter: {
     card: 'summary',

--- a/web/app/movie/[movie]/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/movie/[movie]/city/[city]/cinema/[cinema]/page.tsx
@@ -36,7 +36,13 @@ export async function generateMetadata({
     return {}
   }
 
-  return buildMoviePageMetadata(data.movie, movieSlug, city, cinema)
+  return buildMoviePageMetadata(
+    data.movie,
+    movieSlug,
+    data.screenings,
+    city,
+    cinema,
+  )
 }
 
 export default async function CityCinemaMoviePage({

--- a/web/app/movie/[movie]/city/[city]/page.tsx
+++ b/web/app/movie/[movie]/city/[city]/page.tsx
@@ -37,7 +37,7 @@ export async function generateMetadata({
     return {}
   }
 
-  return buildMoviePageMetadata(data.movie, movieSlug, city)
+  return buildMoviePageMetadata(data.movie, movieSlug, data.screenings, city)
 }
 
 export default async function CityMoviePage({

--- a/web/app/movie/[movie]/page.tsx
+++ b/web/app/movie/[movie]/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata({
     return {}
   }
 
-  return buildMoviePageMetadata(data.movie, movieSlug)
+  return buildMoviePageMetadata(data.movie, movieSlug, data.screenings)
 }
 
 export default async function MoviePageRoute({

--- a/web/app/movie/page.tsx
+++ b/web/app/movie/page.tsx
@@ -5,10 +5,12 @@ import { MoviesOverview } from '../../components/MoviesOverview'
 import { NavigationBar } from '../../components/NavigationBar'
 import { Layout } from '../../components/Layout'
 import { getMovies } from '../../utils/getMovies'
+import { defaultDescription } from '../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'Movies – Expat Cinema',
+  description: defaultDescription,
   alternates: { canonical: getCanonicalUrl('/movie') },
 }
 

--- a/web/app/movie/unmatched/page.tsx
+++ b/web/app/movie/unmatched/page.tsx
@@ -5,10 +5,14 @@ import { NavigationBar } from '../../../components/NavigationBar'
 import { Layout } from '../../../components/Layout'
 import { UnmatchedMoviesOverview } from '../../../components/UnmatchedMoviesOverview'
 import { getScreenings } from '../../../utils/getScreenings'
+import { truncateDescription } from '../../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../../utils/siteUrl'
 
 export const metadata: Metadata = {
   title: 'Unmatched movies – Expat Cinema',
+  description: truncateDescription(
+    'Internal review page for Expat Cinema screenings that have not yet been matched to movie metadata.',
+  ),
   alternates: { canonical: getCanonicalUrl('/movie/unmatched') },
   robots: {
     index: false,

--- a/web/app/statistics/page.tsx
+++ b/web/app/statistics/page.tsx
@@ -4,11 +4,15 @@ import React, { Suspense } from 'react'
 import { Layout } from '../../components/Layout'
 import { NavigationBar } from '../../components/NavigationBar'
 import { PageTitle } from '../../components/PageTitle'
+import { truncateDescription } from '../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../utils/siteUrl'
 import { StatisticsClient } from './StatisticsClient'
 
 export const metadata: Metadata = {
   title: 'Statistics – Expat Cinema',
+  description: truncateDescription(
+    'Statistics for Expat Cinema screening coverage, showing scraper activity and collected English-subtitled movie listings.',
+  ),
   alternates: { canonical: getCanonicalUrl('/statistics') },
 }
 

--- a/web/utils/getMoviePageData.ts
+++ b/web/utils/getMoviePageData.ts
@@ -2,9 +2,15 @@ import type { Metadata } from 'next'
 
 import { getCinema } from './getCinema'
 import { getCity } from './getCity'
-import { getMovieReleaseYear, getMovieSlug, Movie } from './getMovies'
+import {
+  getMoviePosterUrl,
+  getMovieReleaseYear,
+  getMovieSlug,
+  Movie,
+} from './getMovies'
 import { Screening } from './getScreenings'
 import { getMoviePagePath } from './getMoviePagePath'
+import { buildMovieDescription } from './seoMetadata'
 import { getCanonicalUrl } from './siteUrl'
 
 const getMovieIdScreeningCounts = (screenings: Screening[]) =>
@@ -133,6 +139,7 @@ export const getMovieRouteSlugs = (
 export const buildMoviePageMetadata = (
   movie: Movie,
   movieSlug: string,
+  screenings: Screening[],
   city?: string,
   cinema?: string,
 ): Metadata => {
@@ -145,13 +152,43 @@ export const buildMoviePageMetadata = (
       : cinemaName
     : cityName
   const title = `${movie.title}${movieYear ? ` (${movieYear})` : ''}`
+  const description = buildMovieDescription(
+    title,
+    movie.tmdb?.overview ?? undefined,
+    screenings,
+    locationLabel,
+  )
+  const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath, 'w342')
 
   return {
     title: locationLabel
       ? `${title} in ${locationLabel} – Expat Cinema`
       : `${title} – Expat Cinema`,
+    description,
     alternates: {
       canonical: getCanonicalUrl(getMoviePagePath(movieSlug, city, cinema)),
+    },
+    openGraph: {
+      title: locationLabel
+        ? `${title} in ${locationLabel} – Expat Cinema`
+        : `${title} – Expat Cinema`,
+      description,
+      images: posterUrl
+        ? [
+            {
+              url: posterUrl,
+              alt: `Poster for ${movie.title}`,
+            },
+          ]
+        : undefined,
+    },
+    twitter: {
+      card: posterUrl ? 'summary_large_image' : 'summary',
+      title: locationLabel
+        ? `${title} in ${locationLabel} – Expat Cinema`
+        : `${title} – Expat Cinema`,
+      description,
+      images: posterUrl ? [posterUrl] : undefined,
     },
   }
 }

--- a/web/utils/seoMetadata.ts
+++ b/web/utils/seoMetadata.ts
@@ -1,0 +1,83 @@
+import type { Screening } from './getScreenings'
+
+export const defaultDescription =
+  'Find foreign-language movie screenings with English subtitles at cinemas across the Netherlands.'
+
+const descriptionMaxLength = 155
+
+export const truncateDescription = (description: string) => {
+  const normalized = description.replace(/\s+/g, ' ').trim()
+
+  if (normalized.length <= descriptionMaxLength) {
+    return normalized
+  }
+
+  const truncated = normalized.slice(0, descriptionMaxLength - 1)
+  const lastSpaceIndex = truncated.lastIndexOf(' ')
+
+  return `${truncated.slice(0, lastSpaceIndex > 0 ? lastSpaceIndex : undefined)}...`
+}
+
+export const formatList = (items: string[]) => {
+  const uniqueItems = Array.from(new Set(items)).filter(Boolean)
+
+  if (uniqueItems.length <= 1) {
+    return uniqueItems[0] ?? ''
+  }
+
+  if (uniqueItems.length === 2) {
+    return `${uniqueItems[0]} and ${uniqueItems[1]}`
+  }
+
+  return `${uniqueItems.slice(0, -1).join(', ')}, and ${
+    uniqueItems[uniqueItems.length - 1]
+  }`
+}
+
+export const getScreeningCinemaNames = (screenings: Screening[], limit = 4) =>
+  Array.from(
+    new Set(screenings.map((screening) => screening.cinema.name)),
+  ).slice(0, limit)
+
+export const getScreeningCityNames = (screenings: Screening[], limit = 4) =>
+  Array.from(
+    new Set(screenings.map((screening) => screening.cinema.city.name)),
+  ).slice(0, limit)
+
+export const buildCityDescription = (
+  cityName: string,
+  screenings: Screening[],
+) => {
+  const cinemaNames = getScreeningCinemaNames(screenings)
+  const cinemaLabel = formatList(cinemaNames)
+
+  return truncateDescription(
+    cinemaLabel
+      ? `Find English-subtitled movie screenings in ${cityName}, including films at ${cinemaLabel}.`
+      : `Find English-subtitled movie screenings in ${cityName}.`,
+  )
+}
+
+export const buildCinemaDescription = (cinemaName: string, cityName: string) =>
+  truncateDescription(
+    `Find English-subtitled movie screenings at ${cinemaName} in ${cityName}, with dates, times, and booking links.`,
+  )
+
+export const buildMovieDescription = (
+  movieTitle: string,
+  overview: string | undefined,
+  screenings: Screening[],
+  locationLabel: string | null,
+) => {
+  const cityNames = getScreeningCityNames(screenings, 3)
+  const cityLabel = formatList(cityNames)
+  const availability = locationLabel
+    ? `English-subtitled screenings in ${locationLabel}.`
+    : cityLabel
+      ? `English-subtitled screenings in ${cityLabel}.`
+      : 'English-subtitled screenings in the Netherlands.'
+
+  return truncateDescription(
+    overview ? `${overview} ${availability}` : `${movieTitle}: ${availability}`,
+  )
+}


### PR DESCRIPTION
## Summary
- Add reusable SEO metadata helpers for default descriptions, dynamic snippets, and list formatting.
- Add page-specific descriptions for homepage, static pages, city pages, cinema pages, and movie pages.
- Improve city and cinema page title patterns around English-subtitled movie search intent.
- Add poster-based Open Graph and Twitter image metadata for movie pages when poster data is available.

Closes #333.
Closes #336.
Closes #337.

## Validation
- `pnpm --dir web exec eslint 'app/(screenings)/city/[city]/cinema/[cinema]/page.tsx' 'app/(screenings)/city/[city]/page.tsx' 'app/(screenings)/page.tsx' app/about/page.tsx app/layout.tsx app/movie/page.tsx 'app/movie/[movie]/page.tsx' 'app/movie/[movie]/city/[city]/page.tsx' 'app/movie/[movie]/city/[city]/cinema/[cinema]/page.tsx' app/movie/unmatched/page.tsx app/statistics/page.tsx utils/getMoviePageData.ts utils/seoMetadata.ts`
- `pnpm --dir web exec tsc --noEmit --pretty false`
- `pnpm --dir web exec next build` with network access
- Sampled generated HTML for `/movie/exit-8`, `/city/amsterdam`, `/city/amsterdam/cinema/lab111`, `/`, `/about`, `/movie`, and `/statistics`