### PR TITLE
Add structured data for movie pages

### DIFF
--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -34,5 +34,7 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/pnpm-lock.yaml') }}-
       - name: Install dependencies
         run: pnpm install
+      - name: Validate cinema data
+        run: pnpm validate:cinemas
       - name: Build with Next.js
         run: pnpm next build

--- a/.github/workflows/web-build.yml
+++ b/.github/workflows/web-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'web/**'
+      - 'scripts/validate-cinemas.mjs'
       - '.github/workflows/web-build.yml'
 
 defaults:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -87,6 +87,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml') }}-
       - name: Install dependencies
         run: ${{ env.package-manager }} ${{ env.package-manager-command }}
+      - name: Validate cinema data
+        run: ${{ env.package-manager-runner }} validate:cinemas
       - name: Build with Next.js
         run: ${{ env.package-manager-runner }} next build
       - name: Generate a sitemap

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - 'web/**'
+      - 'scripts/validate-cinemas.mjs'
       - '.github/workflows/web.yml'
   schedule:
     - cron: '30 3 * * *' # daily at 3.30 UTC.

--- a/docs/cinema-research.md
+++ b/docs/cinema-research.md
@@ -1,6 +1,6 @@
 # Cinema Research
 
-This file tracks which cinemas in the Netherlands have been researched for English-subtitled screenings, and their outcome. Use it to avoid re-researching the same cinemas in future sessions.
+This file tracks which cinemas in the Netherlands have been researched for screenings with English subtitles, and their outcome. Use it to avoid re-researching the same cinemas in future sessions.
 
 ---
 
@@ -50,7 +50,7 @@ The canonical list of active scrapers is the `SCRAPERS` object in `cloud/scraper
 
 ## GitHub issues filed — awaiting scrapers
 
-Cinemas confirmed to have English-subtitled screenings; GitHub issues created.
+Cinemas confirmed to have screenings with English subtitles; GitHub issues created.
 
 | Cinema                                      | City                           | Program                                              | Issue | URL                                                                           |
 | ------------------------------------------- | ------------------------------ | ---------------------------------------------------- | ----- | ----------------------------------------------------------------------------- |

--- a/scripts/validate-cinemas.mjs
+++ b/scripts/validate-cinemas.mjs
@@ -4,7 +4,7 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
 const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
-const webDirectory = path.resolve(scriptDirectory, '..')
+const webDirectory = path.resolve(scriptDirectory, '..', 'web')
 const cinemasPath = path.join(webDirectory, 'data', 'cinema.json')
 const citiesPath = path.join(webDirectory, 'data', 'city.json')
 

--- a/web/.env.development
+++ b/web/.env.development
@@ -1,5 +1,5 @@
-# Used for Gatsby development builds
-# NEXT_PUBLIC_FEATURE_FLAGS=virtualized-table
+# Build-time feature flags, separated by whitespace.
+FEATURE_FLAGS=structured-data
 
 # prod stage
 PUBLIC_BUCKET=expatcinema-public-prod

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,5 +1,5 @@
-# Used for Gatsby production builds, not Serverless Framework stage
-# NEXT_PUBLIC_FEATURE_FLAGS=virtualized-table
+# Build-time feature flags, separated by whitespace.
+FEATURE_FLAGS=structured-data
 
 # prod stage of cloud stack
 PUBLIC_BUCKET=expatcinema-public-prod

--- a/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata({
   const cityName = getCity(cinemaData?.city ?? city)?.name ?? city
 
   return {
-    title: `English-Subtitled Movies at ${cinemaName}, ${cityName} – Expat Cinema`,
+    title: `Foreign movies with English subtitles at ${cinemaName}, ${cityName} – Expat Cinema`,
     description: buildCinemaDescription(cinemaName, cityName),
     alternates: {
       canonical: getCanonicalUrl(`/city/${city}/cinema/${cinema}`),

--- a/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import { Suspense } from 'react'
 
 import { App } from '../../../../../../components/App'
+import { CinemaInfoBar } from '../../../../../../components/CinemaInfoBar'
+import { Layout } from '../../../../../../components/Layout'
 import cinemas from '../../../../../../data/cinema.json'
 import { getCinema } from '../../../../../../utils/getCinema'
 import { getCity } from '../../../../../../utils/getCity'
@@ -40,6 +42,7 @@ export default async function CinemaPage({
   params: Promise<{ city: string; cinema: string }>
 }) {
   const { city, cinema } = await params
+  const cinemaData = getCinema(cinema)
   const screenings = (await getScreenings()).filter(
     (screening) =>
       screening.cinema.city.slug === city && screening.cinema.slug === cinema,
@@ -47,6 +50,11 @@ export default async function CinemaPage({
 
   return (
     <Suspense>
+      {cinemaData ? (
+        <Layout>
+          <CinemaInfoBar cinema={cinemaData} />
+        </Layout>
+      ) : null}
       <App screenings={screenings} currentCity={city} currentCinema={cinema} />
     </Suspense>
   )

--- a/web/app/(screenings)/city/[city]/page.tsx
+++ b/web/app/(screenings)/city/[city]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({
   )
 
   return {
-    title: `English-Subtitled Movies in ${cityName} – Expat Cinema`,
+    title: `Foreign movies with English subtitles in ${cityName} – Expat Cinema`,
     description: buildCityDescription(cityName, screenings),
     alternates: { canonical: getCanonicalUrl(`/city/${city}`) },
   }

--- a/web/components/CinemaInfoBar.tsx
+++ b/web/components/CinemaInfoBar.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+import { css } from 'styled-system/css'
+
+type CinemaInfo = {
+  name: string
+  url: string
+  address: {
+    streetAddress: string
+    postalCode: string
+    addressLocality: string
+    googleMapsUrl: string
+  }
+}
+
+const barStyle = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  gap: '8px 14px',
+  marginTop: '16px',
+  padding: '10px 12px',
+  borderRadius: '10px',
+  backgroundColor: 'var(--background-highlight-color)',
+  color: 'var(--text-color)',
+  fontSize: '15px',
+  lineHeight: '1.35',
+})
+
+const nameStyle = css({
+  fontWeight: '700',
+})
+
+const addressStyle = css({
+  color: 'var(--text-muted-color)',
+})
+
+const linkStyle = css({
+  color: 'var(--secondary-color)',
+  fontWeight: '700',
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+  '&:hover': {
+    textDecoration: 'underline',
+  },
+})
+
+export const CinemaInfoBar = ({ cinema }: { cinema: CinemaInfo }) => {
+  const { address } = cinema
+  const addressLabel = `${address.streetAddress}, ${address.postalCode} ${address.addressLocality}`
+
+  return (
+    <aside className={barStyle} aria-label={`${cinema.name} information`}>
+      <span className={nameStyle}>{cinema.name}</span>
+      <span className={addressStyle}>{addressLabel}</span>
+      <a
+        className={linkStyle}
+        href={cinema.url}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Website
+      </a>
+      <a
+        className={linkStyle}
+        href={address.googleMapsUrl}
+        target="_blank"
+        rel="noreferrer"
+      >
+        Google Maps
+      </a>
+    </aside>
+  )
+}

--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -10,6 +10,15 @@ import { headerFont } from '../utils/theme'
 import { getMoviePosterUrl, getMovieReleaseYear } from '../utils/getMovies'
 import type { Movie, MovieVideo } from '../utils/getMovies'
 import type { Screening } from '../utils/getScreenings'
+import {
+  buildBreadcrumbJsonLd,
+  buildMovieJsonLd,
+  buildScreeningEventJsonLd,
+  serializeJsonLd,
+} from '../utils/jsonLd'
+import { getCinema } from '../utils/getCinema'
+import { getCity } from '../utils/getCity'
+import { getMovieDescription } from '../utils/seoMetadata'
 import { Calendar } from './Calendar'
 import { Layout } from './Layout'
 import { MovieLocationFilters } from './MovieLocationFilters'
@@ -194,6 +203,12 @@ const getTrailer = (movie: Movie) => {
   )
 }
 
+const isUpcomingScreening = (screening: Screening) => {
+  const screeningTime = Date.parse(screening.date)
+
+  return Number.isFinite(screeningTime) && screeningTime >= Date.now()
+}
+
 export const MoviePage = ({
   movie,
   movieSlug,
@@ -223,9 +238,34 @@ export const MoviePage = ({
   const runtime = formatRuntime(movie.tmdb?.runtime)
   const description = movie.tmdb?.overview
   const trailer = getTrailer(movie)
+  const cityName = currentCity ? getCity(currentCity)?.name : undefined
+  const cinemaName = currentCinema ? getCinema(currentCinema)?.name : undefined
+  const upcomingScreenings = screenings.filter(isUpcomingScreening)
+  const jsonLd = [
+    buildMovieJsonLd(
+      movie,
+      movieSlug,
+      getMovieDescription(movie.title, description ?? undefined),
+    ),
+    buildBreadcrumbJsonLd(
+      movie,
+      movieSlug,
+      currentCity,
+      currentCinema,
+      cityName,
+      cinemaName,
+    ),
+    ...upcomingScreenings.map((screening) =>
+      buildScreeningEventJsonLd(movie, movieSlug, screening),
+    ),
+  ]
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+      />
       <Suspense>
         <Layout backgroundColor="var(--palette-purple-600)">
           <NavigationBar />

--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -10,6 +10,7 @@ import { headerFont } from '../utils/theme'
 import { getMoviePosterUrl, getMovieReleaseYear } from '../utils/getMovies'
 import type { Movie, MovieVideo } from '../utils/getMovies'
 import type { Screening } from '../utils/getScreenings'
+import { isEnabled, STRUCTURED_DATA_FEATURE } from '../utils/featureFlags'
 import {
   buildBreadcrumbJsonLd,
   buildMovieJsonLd,
@@ -241,6 +242,7 @@ export const MoviePage = ({
   const cityName = currentCity ? getCity(currentCity)?.name : undefined
   const cinemaName = currentCinema ? getCinema(currentCinema)?.name : undefined
   const upcomingScreenings = screenings.filter(isUpcomingScreening)
+  const shouldRenderJsonLd = isEnabled(STRUCTURED_DATA_FEATURE)
   const jsonLd = [
     buildMovieJsonLd(
       movie,
@@ -262,10 +264,12 @@ export const MoviePage = ({
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
-      />
+      {shouldRenderJsonLd ? (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
+        />
+      ) : null}
       <Suspense>
         <Layout backgroundColor="var(--palette-purple-600)">
           <NavigationBar />

--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -11,6 +11,7 @@ import { getMoviePosterUrl, getMovieReleaseYear } from '../utils/getMovies'
 import type { Movie, MovieVideo } from '../utils/getMovies'
 import type { Screening } from '../utils/getScreenings'
 import { isEnabled, STRUCTURED_DATA_FEATURE } from '../utils/featureFlags'
+import { CinemaInfoBar } from './CinemaInfoBar'
 import {
   buildBreadcrumbJsonLd,
   buildMovieJsonLd,
@@ -240,7 +241,8 @@ export const MoviePage = ({
   const description = movie.tmdb?.overview
   const trailer = getTrailer(movie)
   const cityName = currentCity ? getCity(currentCity)?.name : undefined
-  const cinemaName = currentCinema ? getCinema(currentCinema)?.name : undefined
+  const cinemaData = currentCinema ? getCinema(currentCinema) : undefined
+  const cinemaName = cinemaData?.name
   const upcomingScreenings = screenings.filter(isUpcomingScreening)
   const shouldRenderJsonLd = isEnabled(STRUCTURED_DATA_FEATURE)
   const jsonLd = [
@@ -364,6 +366,11 @@ export const MoviePage = ({
               currentCinema={currentCinema}
             />
           </div>
+          {currentCity && currentCinema && cinemaData ? (
+            <div style={{ gridColumn: '1 / -1' }}>
+              <CinemaInfoBar cinema={cinemaData} />
+            </div>
+          ) : null}
           <div style={{ gridColumn: '1 / -1' }}>
             <Suspense>
               <Calendar

--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -205,12 +205,6 @@ const getTrailer = (movie: Movie) => {
   )
 }
 
-const isUpcomingScreening = (screening: Screening) => {
-  const screeningTime = Date.parse(screening.date)
-
-  return Number.isFinite(screeningTime) && screeningTime >= Date.now()
-}
-
 export const MoviePage = ({
   movie,
   movieSlug,
@@ -243,7 +237,6 @@ export const MoviePage = ({
   const cityName = currentCity ? getCity(currentCity)?.name : undefined
   const cinemaData = currentCinema ? getCinema(currentCinema) : undefined
   const cinemaName = cinemaData?.name
-  const upcomingScreenings = screenings.filter(isUpcomingScreening)
   const shouldRenderJsonLd = isEnabled(STRUCTURED_DATA_FEATURE)
   const jsonLd = [
     buildMovieJsonLd(
@@ -259,7 +252,7 @@ export const MoviePage = ({
       cityName,
       cinemaName,
     ),
-    ...upcomingScreenings.map((screening) =>
+    ...screenings.map((screening) =>
       buildScreeningEventJsonLd(movie, movieSlug, screening),
     ),
   ]

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -4,312 +4,542 @@
     "slug": "kijkhuis",
     "city": "leiden",
     "url": "https://bioscopenleiden.nl/kijkhuis/",
-    "logo": "bioscopenleiden.png"
+    "logo": "bioscopenleiden.png",
+    "address": {
+      "streetAddress": "Vrouwenkerksteeg 10",
+      "postalCode": "2312 WS",
+      "addressLocality": "Leiden"
+    }
   },
   {
     "name": "Trianon",
     "slug": "trianon",
     "city": "leiden",
     "url": "https://bioscopenleiden.nl/trianon/",
-    "logo": "bioscopenleiden.png"
+    "logo": "bioscopenleiden.png",
+    "address": {
+      "streetAddress": "Breestraat 31",
+      "postalCode": "2311 CH",
+      "addressLocality": "Leiden"
+    }
   },
   {
     "name": "Lido",
     "slug": "lido",
     "city": "leiden",
     "url": "https://bioscopenleiden.nl/lido/",
-    "logo": "bioscopenleiden.png"
+    "logo": "bioscopenleiden.png",
+    "address": {
+      "streetAddress": "Steenstraat 39",
+      "postalCode": "2312 BV",
+      "addressLocality": "Leiden"
+    }
   },
   {
     "name": "Filmhuis Den Haag",
     "slug": "filmhuis-den-haag",
     "city": "den-haag",
     "url": "https://www.filmhuisdenhaag.nl/",
-    "logo": "filmhuisdenhaag.png"
+    "logo": "filmhuisdenhaag.png",
+    "address": {
+      "streetAddress": "Spui 191",
+      "postalCode": "2511 BN",
+      "addressLocality": "Den Haag"
+    }
   },
   {
     "name": "Filmtheater Hilversum",
     "slug": "filmtheater-hilversum",
     "city": "hilversum",
-    "url": "https://filmtheaterhilversum.nl/"
+    "url": "https://filmtheaterhilversum.nl/",
+    "address": {
+      "streetAddress": "Herenplein 5",
+      "postalCode": "1211 DR",
+      "addressLocality": "Hilversum"
+    }
   },
   {
     "name": "Chassé Cinema",
     "slug": "chasse-cinema",
     "city": "breda",
-    "url": "https://www.chasse.nl"
+    "url": "https://www.chasse.nl",
+    "address": {
+      "streetAddress": "Claudius Prinsenlaan 8",
+      "postalCode": "4811 DK",
+      "addressLocality": "Breda"
+    }
   },
   {
     "name": "Filmtheater De Witt",
     "slug": "filmtheater-de-witt",
     "city": "dordrecht",
-    "url": "https://www.dewittdordrecht.nl/filmtheater/"
+    "url": "https://www.dewittdordrecht.nl/filmtheater/",
+    "address": {
+      "streetAddress": "Nieuwstraat 60-62",
+      "postalCode": "3311 XR",
+      "addressLocality": "Dordrecht"
+    }
   },
   {
     "name": "Kino",
     "slug": "kino",
     "city": "rotterdam",
     "url": "https://www.kinorotterdam.nl/",
-    "logo": "kino.png"
+    "logo": "kino.png",
+    "address": {
+      "streetAddress": "Gouvernestraat 129-133",
+      "postalCode": "3014 PM",
+      "addressLocality": "Rotterdam"
+    }
   },
   {
     "name": "Lantarenvenster",
     "slug": "lantarenvenster",
     "city": "rotterdam",
     "url": "https://www.lantarenvenster.nl/",
-    "logo": "lantarenvenster.png"
+    "logo": "lantarenvenster.png",
+    "address": {
+      "streetAddress": "Otto Reuchlinweg 996",
+      "postalCode": "3072 MD",
+      "addressLocality": "Rotterdam"
+    }
   },
   {
     "name": "Lab-1",
     "slug": "lab-1",
     "city": "eindhoven",
     "url": "https://www.lab-1.nl/",
-    "logo": "lab1.png"
+    "logo": "lab1.png",
+    "address": {
+      "streetAddress": "Keizersgracht 19",
+      "postalCode": "5611 GC",
+      "addressLocality": "Eindhoven"
+    }
   },
   {
     "name": "Lab111",
     "slug": "lab111",
     "city": "amsterdam",
     "url": "https://www.lab111.nl/",
-    "logo": "lab111.png"
+    "logo": "lab111.png",
+    "address": {
+      "streetAddress": "Arie Biemondstraat 111",
+      "postalCode": "1054 PD",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Eye",
     "slug": "eye",
     "city": "amsterdam",
     "url": "https://www.eyefilm.nl/en",
-    "logo": "eye.png"
+    "logo": "eye.png",
+    "address": {
+      "streetAddress": "IJpromenade 1",
+      "postalCode": "1031 KT",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "FC Hyena",
     "slug": "fc-hyena",
     "city": "amsterdam",
-    "url": "https://fchyena.nl/"
+    "url": "https://fchyena.nl/",
+    "address": {
+      "streetAddress": "Aambeeldstraat 24",
+      "postalCode": "1021 KB",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Kriterion",
     "slug": "kriterion",
     "city": "amsterdam",
     "url": "https://kriterion.nl",
-    "logo": "kriterion.png"
+    "logo": "kriterion.png",
+    "address": {
+      "streetAddress": "Roetersstraat 170",
+      "postalCode": "1018 WE",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Springhaver",
     "slug": "springhaver",
     "city": "utrecht",
     "url": "https://www.springhaver.nl",
-    "logo": "springhaver.png"
+    "logo": "springhaver.png",
+    "address": {
+      "streetAddress": "Springweg 50",
+      "postalCode": "3511 VS",
+      "addressLocality": "Utrecht"
+    }
   },
   {
     "name": "Louis Hartlooper Complex",
     "slug": "louis-hartlooper-complex",
     "city": "utrecht",
     "url": "https://www.hartlooper.nl",
-    "logo": "louishartloopercomplex.png"
+    "logo": "louishartloopercomplex.png",
+    "address": {
+      "streetAddress": "Tolsteegbrug 1",
+      "postalCode": "3511 ZN",
+      "addressLocality": "Utrecht"
+    }
   },
   {
     "name": "Slachtstraat",
     "slug": "slachtstraat",
     "city": "utrecht",
     "url": "https://www.slachtstraat.nl",
-    "logo": "slachtstraat.png"
+    "logo": "slachtstraat.png",
+    "address": {
+      "streetAddress": "Slachtstraat 5",
+      "postalCode": "3512 BC",
+      "addressLocality": "Utrecht"
+    }
   },
   {
     "name": "De Sien",
     "slug": "de-sien",
     "city": "utrecht",
-    "url": "https://desienfilm.nl"
+    "url": "https://desienfilm.nl",
+    "address": {
+      "streetAddress": "Kanaalweg 30",
+      "postalCode": "3526 KM",
+      "addressLocality": "Utrecht"
+    }
   },
   {
     "name": "Slieker Film",
     "slug": "slieker-film",
     "city": "leeuwarden",
-    "url": "https://sliekerfilm.nl/"
+    "url": "https://sliekerfilm.nl/",
+    "address": {
+      "streetAddress": "Wilhelminaplein 92",
+      "postalCode": "8911 BS",
+      "addressLocality": "Leeuwarden"
+    }
   },
   {
     "name": "Rialto De Pijp",
     "slug": "rialto-de-pijp",
     "city": "amsterdam",
     "url": "https://rialtofilm.nl/",
-    "logo": "rialto.png"
+    "logo": "rialto.png",
+    "address": {
+      "streetAddress": "Ceintuurbaan 338",
+      "postalCode": "1072 GN",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Rialto VU",
     "slug": "rialto-vu",
     "city": "amsterdam",
     "url": "https://rialtofilm.nl/",
-    "logo": "rialto.png"
+    "logo": "rialto.png",
+    "address": {
+      "streetAddress": "De Boelelaan 1111",
+      "postalCode": "1081 HV",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Cinecenter",
     "slug": "cinecenter",
     "city": "amsterdam",
     "url": "https://cinecenter.nl/",
-    "logo": "cinecenter.png"
+    "logo": "cinecenter.png",
+    "address": {
+      "streetAddress": "Lijnbaansgracht 236",
+      "postalCode": "1017 PH",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Cinema de Vlugt",
     "slug": "cinema-de-vlugt",
     "city": "amsterdam",
-    "url": "https://www.cinemadevlugt.nl/"
+    "url": "https://www.cinemadevlugt.nl/",
+    "address": {
+      "streetAddress": "Burgemeester de Vlugtlaan 125",
+      "postalCode": "1063 BJ",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Forum Groningen",
     "slug": "forum-groningen",
     "city": "groningen",
     "url": "https://www.forum.nl/",
-    "logo": "forumgroningen.png"
+    "logo": "forumgroningen.png",
+    "address": {
+      "streetAddress": "Nieuwe Markt 1",
+      "postalCode": "9712 KN",
+      "addressLocality": "Groningen"
+    }
   },
   {
     "name": "Heerenstraat Theater",
     "slug": "heerenstraat-theater",
     "city": "wageningen",
-    "url": "https://www.heerenstraattheater.nl/"
+    "url": "https://www.heerenstraattheater.nl/",
+    "address": {
+      "streetAddress": "Molenstraat 1B",
+      "postalCode": "6701 DM",
+      "addressLocality": "Wageningen"
+    }
   },
   {
     "name": "Filmhuis Lumen",
     "slug": "filmhuis-lumen",
     "city": "delft",
     "url": "https://www.filmhuis-lumen.nl/",
-    "logo": "filmhuislumen.png"
+    "logo": "filmhuislumen.png",
+    "address": {
+      "streetAddress": "Van Leeuwenhoekpark 55",
+      "postalCode": "2611 DW",
+      "addressLocality": "Delft"
+    }
   },
   {
     "name": "Ketelhuis",
     "slug": "ketelhuis",
     "city": "amsterdam",
     "url": "https://www.ketelhuis.nl/",
-    "logo": "ketelhuis.png"
+    "logo": "ketelhuis.png",
+    "address": {
+      "streetAddress": "Pazzanistraat 4",
+      "postalCode": "1014 DB",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Lumière",
     "slug": "lumiere",
     "city": "maastricht",
     "url": "https://lumiere.nl/",
-    "logo": "lumiere.png"
+    "logo": "lumiere.png",
+    "address": {
+      "streetAddress": "Bassin 88",
+      "postalCode": "6211 AK",
+      "addressLocality": "Maastricht"
+    }
   },
   {
     "name": "Studio/K",
     "slug": "studio-k",
     "city": "amsterdam",
     "url": "https://www.studio-k.nu/",
-    "logo": "studiok.png"
+    "logo": "studiok.png",
+    "address": {
+      "streetAddress": "Timorplein 62",
+      "postalCode": "1094 CC",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "De Uitkijk",
     "slug": "de-uitkijk",
     "city": "amsterdam",
     "url": "https://www.uitkijk.nl/",
-    "logo": "deuitkijk.png"
+    "logo": "deuitkijk.png",
+    "address": {
+      "streetAddress": "Prinsengracht 452",
+      "postalCode": "1017 KE",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "The Movies",
     "slug": "the-movies",
     "city": "amsterdam",
     "url": "https://www.themovies.nl/",
-    "logo": "themovies.png"
+    "logo": "themovies.png",
+    "address": {
+      "streetAddress": "Haarlemmerdijk 161",
+      "postalCode": "1013 KH",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Cinecitta",
     "slug": "cinecitta",
     "city": "tilburg",
     "url": "https://cinecitta.nl/",
-    "logo": "cinecitta.png"
+    "logo": "cinecitta.png",
+    "address": {
+      "streetAddress": "Willem II Straat 29",
+      "postalCode": "5038 BA",
+      "addressLocality": "Tilburg"
+    }
   },
   {
     "name": "Schuur",
     "slug": "schuur",
     "city": "haarlem",
     "url": "https://schuur.nl/",
-    "logo": "schuur.png"
+    "logo": "schuur.png",
+    "address": {
+      "streetAddress": "Lange Begijnestraat 9",
+      "postalCode": "2011 HH",
+      "addressLocality": "Haarlem"
+    }
   },
   {
     "name": "Lux",
     "slug": "lux",
     "city": "nijmegen",
     "url": "https://www.lux-nijmegen.nl",
-    "logo": "lux.png"
+    "logo": "lux.png",
+    "address": {
+      "streetAddress": "Mariënburg 38-39",
+      "postalCode": "6511 PS",
+      "addressLocality": "Nijmegen"
+    }
   },
   {
     "name": "De Filmhallen",
     "slug": "de-filmhallen",
     "city": "amsterdam",
     "url": "https://www.filmhallen.nl/",
-    "logo": "defilmhallen.png"
+    "logo": "defilmhallen.png",
+    "address": {
+      "streetAddress": "Hannie Dankbaarpassage 12",
+      "postalCode": "1053 RT",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Filmkoepel",
     "slug": "filmkoepel",
     "city": "haarlem",
     "url": "https://www.filmkoepel.nl/",
-    "logo": "defilmhallen.png"
+    "logo": "defilmhallen.png",
+    "address": {
+      "streetAddress": "Koepelplein 1b",
+      "postalCode": "2031 WL",
+      "addressLocality": "Haarlem"
+    }
   },
   {
     "name": "Cinerama",
     "slug": "cinerama",
     "city": "rotterdam",
     "url": "https://cineramabios.nl/",
-    "logo": "cinerama.png"
+    "logo": "cinerama.png",
+    "address": {
+      "streetAddress": "Westblaak 18",
+      "postalCode": "3012 KL",
+      "addressLocality": "Rotterdam"
+    }
   },
   {
     "name": "WORM",
     "slug": "worm",
     "city": "rotterdam",
-    "url": "https://worm.org/"
+    "url": "https://worm.org/",
+    "address": {
+      "streetAddress": "Boomgaardsstraat 71",
+      "postalCode": "3012 XA",
+      "addressLocality": "Rotterdam"
+    }
   },
   {
     "name": "Melkweg",
     "slug": "melkweg",
     "city": "amsterdam",
     "url": "https://www.melkweg.nl/en/film/",
-    "logo": "melkweg.svg"
+    "logo": "melkweg.svg",
+    "address": {
+      "streetAddress": "Lijnbaansgracht 234A",
+      "postalCode": "1017 PH",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Natlab",
     "slug": "natlab",
     "city": "eindhoven",
     "url": "https://www.natlab.nl/",
-    "logo": "natlab.png"
+    "logo": "natlab.png",
+    "address": {
+      "streetAddress": "Kastanjelaan 500",
+      "postalCode": "5616 LZ",
+      "addressLocality": "Eindhoven"
+    }
   },
   {
     "name": "Focus Arnhem",
     "slug": "focus-arnhem",
     "city": "arnhem",
     "url": "https://www.focusarnhem.nl/",
-    "logo": "focusarnhem.png"
+    "logo": "focusarnhem.png",
+    "address": {
+      "streetAddress": "Audrey Hepburnplein 1",
+      "postalCode": "6811 EH",
+      "addressLocality": "Arnhem"
+    }
   },
   {
     "name": "Het Documentaire Paviljoen",
     "slug": "het-documentaire-paviljoen",
     "city": "amsterdam",
     "url": "https://www.idfa.nl/en/vondelpark/",
-    "logo": "idfa.png"
+    "logo": "idfa.png",
+    "address": {
+      "streetAddress": "Vondelpark 3",
+      "postalCode": "1071 AA",
+      "addressLocality": "Amsterdam"
+    }
   },
   {
     "name": "Concordia",
     "slug": "concordia",
     "city": "enschede",
     "url": "https://www.concordia.nl/",
-    "logo": "concordia.png"
+    "logo": "concordia.png",
+    "address": {
+      "streetAddress": "Oude Markt 15",
+      "postalCode": "7511 GA",
+      "addressLocality": "Enschede"
+    }
   },
   {
     "name": "Flora Filmtheater",
     "slug": "flora-filmtheater",
     "city": "den-haag",
     "url": "https://florafilmtheater.nl/",
-    "logo": "florafilmtheater.png"
+    "logo": "florafilmtheater.png",
+    "address": {
+      "streetAddress": "De Constant Rebecquestraat 55",
+      "postalCode": "2518 RC",
+      "addressLocality": "Den Haag"
+    }
   },
   {
     "name": "Dokhuis",
     "slug": "dokhuis",
     "city": "rotterdam",
     "url": "https://dokhuis.org/",
-    "logo": "dokhuis.png"
+    "logo": "dokhuis.png",
+    "address": {
+      "streetAddress": "Doklaan 10",
+      "postalCode": "3087 CB",
+      "addressLocality": "Rotterdam"
+    }
   },
   {
     "name": "Cinema Amstelveen",
     "slug": "cinema-amstelveen",
     "city": "amstelveen",
     "url": "https://schouwburgamstelveen.nl/nl/cinema/",
-    "logo": "cinema-amstelveen.png"
+    "logo": "cinema-amstelveen.png",
+    "address": {
+      "streetAddress": "Stadsplein 100",
+      "postalCode": "1181 ZM",
+      "addressLocality": "Amstelveen"
+    }
   }
 ]

--- a/web/data/cinema.json
+++ b/web/data/cinema.json
@@ -8,7 +8,8 @@
     "address": {
       "streetAddress": "Vrouwenkerksteeg 10",
       "postalCode": "2312 WS",
-      "addressLocality": "Leiden"
+      "addressLocality": "Leiden",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Kijkhuis%2C%20Vrouwenkerksteeg%2010%2C%202312%20WS%20Leiden%2C%20Netherlands"
     }
   },
   {
@@ -20,7 +21,8 @@
     "address": {
       "streetAddress": "Breestraat 31",
       "postalCode": "2311 CH",
-      "addressLocality": "Leiden"
+      "addressLocality": "Leiden",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Trianon%2C%20Breestraat%2031%2C%202311%20CH%20Leiden%2C%20Netherlands"
     }
   },
   {
@@ -32,7 +34,8 @@
     "address": {
       "streetAddress": "Steenstraat 39",
       "postalCode": "2312 BV",
-      "addressLocality": "Leiden"
+      "addressLocality": "Leiden",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Lido%2C%20Steenstraat%2039%2C%202312%20BV%20Leiden%2C%20Netherlands"
     }
   },
   {
@@ -44,7 +47,8 @@
     "address": {
       "streetAddress": "Spui 191",
       "postalCode": "2511 BN",
-      "addressLocality": "Den Haag"
+      "addressLocality": "Den Haag",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Filmhuis%20Den%20Haag%2C%20Spui%20191%2C%202511%20BN%20Den%20Haag%2C%20Netherlands"
     }
   },
   {
@@ -55,7 +59,8 @@
     "address": {
       "streetAddress": "Herenplein 5",
       "postalCode": "1211 DR",
-      "addressLocality": "Hilversum"
+      "addressLocality": "Hilversum",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Filmtheater%20Hilversum%2C%20Herenplein%205%2C%201211%20DR%20Hilversum%2C%20Netherlands"
     }
   },
   {
@@ -66,7 +71,8 @@
     "address": {
       "streetAddress": "Claudius Prinsenlaan 8",
       "postalCode": "4811 DK",
-      "addressLocality": "Breda"
+      "addressLocality": "Breda",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Chass%C3%A9%20Cinema%2C%20Claudius%20Prinsenlaan%208%2C%204811%20DK%20Breda%2C%20Netherlands"
     }
   },
   {
@@ -77,7 +83,8 @@
     "address": {
       "streetAddress": "Nieuwstraat 60-62",
       "postalCode": "3311 XR",
-      "addressLocality": "Dordrecht"
+      "addressLocality": "Dordrecht",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Filmtheater%20De%20Witt%2C%20Nieuwstraat%2060-62%2C%203311%20XR%20Dordrecht%2C%20Netherlands"
     }
   },
   {
@@ -89,7 +96,8 @@
     "address": {
       "streetAddress": "Gouvernestraat 129-133",
       "postalCode": "3014 PM",
-      "addressLocality": "Rotterdam"
+      "addressLocality": "Rotterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Kino%2C%20Gouvernestraat%20129-133%2C%203014%20PM%20Rotterdam%2C%20Netherlands"
     }
   },
   {
@@ -101,7 +109,8 @@
     "address": {
       "streetAddress": "Otto Reuchlinweg 996",
       "postalCode": "3072 MD",
-      "addressLocality": "Rotterdam"
+      "addressLocality": "Rotterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Lantarenvenster%2C%20Otto%20Reuchlinweg%20996%2C%203072%20MD%20Rotterdam%2C%20Netherlands"
     }
   },
   {
@@ -113,7 +122,8 @@
     "address": {
       "streetAddress": "Keizersgracht 19",
       "postalCode": "5611 GC",
-      "addressLocality": "Eindhoven"
+      "addressLocality": "Eindhoven",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Lab-1%2C%20Keizersgracht%2019%2C%205611%20GC%20Eindhoven%2C%20Netherlands"
     }
   },
   {
@@ -125,7 +135,8 @@
     "address": {
       "streetAddress": "Arie Biemondstraat 111",
       "postalCode": "1054 PD",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Lab111%2C%20Arie%20Biemondstraat%20111%2C%201054%20PD%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -137,7 +148,8 @@
     "address": {
       "streetAddress": "IJpromenade 1",
       "postalCode": "1031 KT",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Eye%2C%20IJpromenade%201%2C%201031%20KT%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -148,7 +160,8 @@
     "address": {
       "streetAddress": "Aambeeldstraat 24",
       "postalCode": "1021 KB",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=FC%20Hyena%2C%20Aambeeldstraat%2024%2C%201021%20KB%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -160,7 +173,8 @@
     "address": {
       "streetAddress": "Roetersstraat 170",
       "postalCode": "1018 WE",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Kriterion%2C%20Roetersstraat%20170%2C%201018%20WE%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -172,7 +186,8 @@
     "address": {
       "streetAddress": "Springweg 50",
       "postalCode": "3511 VS",
-      "addressLocality": "Utrecht"
+      "addressLocality": "Utrecht",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Springhaver%2C%20Springweg%2050%2C%203511%20VS%20Utrecht%2C%20Netherlands"
     }
   },
   {
@@ -184,7 +199,8 @@
     "address": {
       "streetAddress": "Tolsteegbrug 1",
       "postalCode": "3511 ZN",
-      "addressLocality": "Utrecht"
+      "addressLocality": "Utrecht",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Louis%20Hartlooper%20Complex%2C%20Tolsteegbrug%201%2C%203511%20ZN%20Utrecht%2C%20Netherlands"
     }
   },
   {
@@ -196,7 +212,8 @@
     "address": {
       "streetAddress": "Slachtstraat 5",
       "postalCode": "3512 BC",
-      "addressLocality": "Utrecht"
+      "addressLocality": "Utrecht",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Slachtstraat%2C%20Slachtstraat%205%2C%203512%20BC%20Utrecht%2C%20Netherlands"
     }
   },
   {
@@ -207,7 +224,8 @@
     "address": {
       "streetAddress": "Kanaalweg 30",
       "postalCode": "3526 KM",
-      "addressLocality": "Utrecht"
+      "addressLocality": "Utrecht",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=De%20Sien%2C%20Kanaalweg%2030%2C%203526%20KM%20Utrecht%2C%20Netherlands"
     }
   },
   {
@@ -218,7 +236,8 @@
     "address": {
       "streetAddress": "Wilhelminaplein 92",
       "postalCode": "8911 BS",
-      "addressLocality": "Leeuwarden"
+      "addressLocality": "Leeuwarden",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Slieker%20Film%2C%20Wilhelminaplein%2092%2C%208911%20BS%20Leeuwarden%2C%20Netherlands"
     }
   },
   {
@@ -230,7 +249,8 @@
     "address": {
       "streetAddress": "Ceintuurbaan 338",
       "postalCode": "1072 GN",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Rialto%20De%20Pijp%2C%20Ceintuurbaan%20338%2C%201072%20GN%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -242,7 +262,8 @@
     "address": {
       "streetAddress": "De Boelelaan 1111",
       "postalCode": "1081 HV",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Rialto%20VU%2C%20De%20Boelelaan%201111%2C%201081%20HV%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -254,7 +275,8 @@
     "address": {
       "streetAddress": "Lijnbaansgracht 236",
       "postalCode": "1017 PH",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Cinecenter%2C%20Lijnbaansgracht%20236%2C%201017%20PH%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -265,7 +287,8 @@
     "address": {
       "streetAddress": "Burgemeester de Vlugtlaan 125",
       "postalCode": "1063 BJ",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Cinema%20de%20Vlugt%2C%20Burgemeester%20de%20Vlugtlaan%20125%2C%201063%20BJ%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -277,7 +300,8 @@
     "address": {
       "streetAddress": "Nieuwe Markt 1",
       "postalCode": "9712 KN",
-      "addressLocality": "Groningen"
+      "addressLocality": "Groningen",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Forum%20Groningen%2C%20Nieuwe%20Markt%201%2C%209712%20KN%20Groningen%2C%20Netherlands"
     }
   },
   {
@@ -288,7 +312,8 @@
     "address": {
       "streetAddress": "Molenstraat 1B",
       "postalCode": "6701 DM",
-      "addressLocality": "Wageningen"
+      "addressLocality": "Wageningen",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Heerenstraat%20Theater%2C%20Molenstraat%201B%2C%206701%20DM%20Wageningen%2C%20Netherlands"
     }
   },
   {
@@ -300,7 +325,8 @@
     "address": {
       "streetAddress": "Van Leeuwenhoekpark 55",
       "postalCode": "2611 DW",
-      "addressLocality": "Delft"
+      "addressLocality": "Delft",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Filmhuis%20Lumen%2C%20Van%20Leeuwenhoekpark%2055%2C%202611%20DW%20Delft%2C%20Netherlands"
     }
   },
   {
@@ -312,7 +338,8 @@
     "address": {
       "streetAddress": "Pazzanistraat 4",
       "postalCode": "1014 DB",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Ketelhuis%2C%20Pazzanistraat%204%2C%201014%20DB%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -324,7 +351,8 @@
     "address": {
       "streetAddress": "Bassin 88",
       "postalCode": "6211 AK",
-      "addressLocality": "Maastricht"
+      "addressLocality": "Maastricht",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Lumi%C3%A8re%2C%20Bassin%2088%2C%206211%20AK%20Maastricht%2C%20Netherlands"
     }
   },
   {
@@ -336,7 +364,8 @@
     "address": {
       "streetAddress": "Timorplein 62",
       "postalCode": "1094 CC",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Studio%2FK%2C%20Timorplein%2062%2C%201094%20CC%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -348,7 +377,8 @@
     "address": {
       "streetAddress": "Prinsengracht 452",
       "postalCode": "1017 KE",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=De%20Uitkijk%2C%20Prinsengracht%20452%2C%201017%20KE%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -360,7 +390,8 @@
     "address": {
       "streetAddress": "Haarlemmerdijk 161",
       "postalCode": "1013 KH",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=The%20Movies%2C%20Haarlemmerdijk%20161%2C%201013%20KH%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -372,7 +403,8 @@
     "address": {
       "streetAddress": "Willem II Straat 29",
       "postalCode": "5038 BA",
-      "addressLocality": "Tilburg"
+      "addressLocality": "Tilburg",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Cinecitta%2C%20Willem%20II%20Straat%2029%2C%205038%20BA%20Tilburg%2C%20Netherlands"
     }
   },
   {
@@ -384,7 +416,8 @@
     "address": {
       "streetAddress": "Lange Begijnestraat 9",
       "postalCode": "2011 HH",
-      "addressLocality": "Haarlem"
+      "addressLocality": "Haarlem",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Schuur%2C%20Lange%20Begijnestraat%209%2C%202011%20HH%20Haarlem%2C%20Netherlands"
     }
   },
   {
@@ -396,7 +429,8 @@
     "address": {
       "streetAddress": "Mariënburg 38-39",
       "postalCode": "6511 PS",
-      "addressLocality": "Nijmegen"
+      "addressLocality": "Nijmegen",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Lux%2C%20Mari%C3%ABnburg%2038-39%2C%206511%20PS%20Nijmegen%2C%20Netherlands"
     }
   },
   {
@@ -408,7 +442,8 @@
     "address": {
       "streetAddress": "Hannie Dankbaarpassage 12",
       "postalCode": "1053 RT",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=De%20Filmhallen%2C%20Hannie%20Dankbaarpassage%2012%2C%201053%20RT%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -420,7 +455,8 @@
     "address": {
       "streetAddress": "Koepelplein 1b",
       "postalCode": "2031 WL",
-      "addressLocality": "Haarlem"
+      "addressLocality": "Haarlem",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Filmkoepel%2C%20Koepelplein%201b%2C%202031%20WL%20Haarlem%2C%20Netherlands"
     }
   },
   {
@@ -432,7 +468,8 @@
     "address": {
       "streetAddress": "Westblaak 18",
       "postalCode": "3012 KL",
-      "addressLocality": "Rotterdam"
+      "addressLocality": "Rotterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Cinerama%2C%20Westblaak%2018%2C%203012%20KL%20Rotterdam%2C%20Netherlands"
     }
   },
   {
@@ -443,7 +480,8 @@
     "address": {
       "streetAddress": "Boomgaardsstraat 71",
       "postalCode": "3012 XA",
-      "addressLocality": "Rotterdam"
+      "addressLocality": "Rotterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=WORM%2C%20Boomgaardsstraat%2071%2C%203012%20XA%20Rotterdam%2C%20Netherlands"
     }
   },
   {
@@ -455,7 +493,8 @@
     "address": {
       "streetAddress": "Lijnbaansgracht 234A",
       "postalCode": "1017 PH",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Melkweg%2C%20Lijnbaansgracht%20234A%2C%201017%20PH%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -467,7 +506,8 @@
     "address": {
       "streetAddress": "Kastanjelaan 500",
       "postalCode": "5616 LZ",
-      "addressLocality": "Eindhoven"
+      "addressLocality": "Eindhoven",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Natlab%2C%20Kastanjelaan%20500%2C%205616%20LZ%20Eindhoven%2C%20Netherlands"
     }
   },
   {
@@ -479,7 +519,8 @@
     "address": {
       "streetAddress": "Audrey Hepburnplein 1",
       "postalCode": "6811 EH",
-      "addressLocality": "Arnhem"
+      "addressLocality": "Arnhem",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Focus%20Arnhem%2C%20Audrey%20Hepburnplein%201%2C%206811%20EH%20Arnhem%2C%20Netherlands"
     }
   },
   {
@@ -491,7 +532,8 @@
     "address": {
       "streetAddress": "Vondelpark 3",
       "postalCode": "1071 AA",
-      "addressLocality": "Amsterdam"
+      "addressLocality": "Amsterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Het%20Documentaire%20Paviljoen%2C%20Vondelpark%203%2C%201071%20AA%20Amsterdam%2C%20Netherlands"
     }
   },
   {
@@ -503,7 +545,8 @@
     "address": {
       "streetAddress": "Oude Markt 15",
       "postalCode": "7511 GA",
-      "addressLocality": "Enschede"
+      "addressLocality": "Enschede",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Concordia%2C%20Oude%20Markt%2015%2C%207511%20GA%20Enschede%2C%20Netherlands"
     }
   },
   {
@@ -515,7 +558,8 @@
     "address": {
       "streetAddress": "De Constant Rebecquestraat 55",
       "postalCode": "2518 RC",
-      "addressLocality": "Den Haag"
+      "addressLocality": "Den Haag",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Flora%20Filmtheater%2C%20De%20Constant%20Rebecquestraat%2055%2C%202518%20RC%20Den%20Haag%2C%20Netherlands"
     }
   },
   {
@@ -527,7 +571,8 @@
     "address": {
       "streetAddress": "Doklaan 10",
       "postalCode": "3087 CB",
-      "addressLocality": "Rotterdam"
+      "addressLocality": "Rotterdam",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Dokhuis%2C%20Doklaan%2010%2C%203087%20CB%20Rotterdam%2C%20Netherlands"
     }
   },
   {
@@ -539,7 +584,8 @@
     "address": {
       "streetAddress": "Stadsplein 100",
       "postalCode": "1181 ZM",
-      "addressLocality": "Amstelveen"
+      "addressLocality": "Amstelveen",
+      "googleMapsUrl": "https://www.google.com/maps/search/?api=1&query=Cinema%20Amstelveen%2C%20Stadsplein%20100%2C%201181%20ZM%20Amstelveen%2C%20Netherlands"
     }
   }
 ]

--- a/web/package.json
+++ b/web/package.json
@@ -8,6 +8,7 @@
     "prepare": "panda codegen",
     "start": "next start",
     "lint": "eslint .",
+    "validate:cinemas": "node scripts/validate-cinemas.mjs",
     "clean": "rm -rf .next out",
     "serve": "pnpm build && serve out"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "prepare": "panda codegen",
     "start": "next start",
     "lint": "eslint .",
-    "validate:cinemas": "node scripts/validate-cinemas.mjs",
+    "validate:cinemas": "node ../scripts/validate-cinemas.mjs",
     "clean": "rm -rf .next out",
     "serve": "pnpm build && serve out"
   },

--- a/web/scripts/validate-cinemas.mjs
+++ b/web/scripts/validate-cinemas.mjs
@@ -1,0 +1,111 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+const webDirectory = path.resolve(scriptDirectory, '..')
+const cinemasPath = path.join(webDirectory, 'data', 'cinema.json')
+const citiesPath = path.join(webDirectory, 'data', 'city.json')
+
+const cinemas = JSON.parse(fs.readFileSync(cinemasPath, 'utf8'))
+const cities = JSON.parse(fs.readFileSync(citiesPath, 'utf8'))
+const cityNameBySlug = new Map(cities.map((city) => [city.slug, city.name]))
+const failures = []
+
+const requireString = (cinema, path, value) => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    failures.push(`${cinema.name}: ${path} is required`)
+  }
+}
+
+for (const cinema of cinemas) {
+  requireString(cinema, 'name', cinema.name)
+  requireString(cinema, 'slug', cinema.slug)
+  requireString(cinema, 'city', cinema.city)
+  requireString(cinema, 'url', cinema.url)
+
+  const expectedLocality = cityNameBySlug.get(cinema.city)
+  if (!expectedLocality) {
+    failures.push(`${cinema.name}: city "${cinema.city}" is not in city.json`)
+  }
+
+  const address = cinema.address
+  if (!address || typeof address !== 'object') {
+    failures.push(`${cinema.name}: address is required`)
+    continue
+  }
+
+  requireString(cinema, 'address.streetAddress', address.streetAddress)
+  requireString(cinema, 'address.postalCode', address.postalCode)
+  requireString(cinema, 'address.addressLocality', address.addressLocality)
+  requireString(cinema, 'address.googleMapsUrl', address.googleMapsUrl)
+
+  if (
+    typeof address.postalCode === 'string' &&
+    !/^\d{4} [A-Z]{2}$/.test(address.postalCode)
+  ) {
+    failures.push(
+      `${cinema.name}: address.postalCode must match "1234 AB", got "${address.postalCode}"`,
+    )
+  }
+
+  if (expectedLocality && address.addressLocality !== expectedLocality) {
+    failures.push(
+      `${cinema.name}: address.addressLocality must match city.json value "${expectedLocality}", got "${address.addressLocality}"`,
+    )
+  }
+
+  let mapsUrl
+  try {
+    mapsUrl = new URL(address.googleMapsUrl)
+  } catch {
+    failures.push(
+      `${cinema.name}: address.googleMapsUrl is not a valid URL: ${address.googleMapsUrl}`,
+    )
+    continue
+  }
+
+  if (mapsUrl.origin !== 'https://www.google.com') {
+    failures.push(
+      `${cinema.name}: address.googleMapsUrl must use https://www.google.com`,
+    )
+  }
+
+  if (mapsUrl.pathname !== '/maps/search/') {
+    failures.push(
+      `${cinema.name}: address.googleMapsUrl must use /maps/search/`,
+    )
+  }
+
+  if (mapsUrl.searchParams.get('api') !== '1') {
+    failures.push(`${cinema.name}: address.googleMapsUrl must include api=1`)
+  }
+
+  const query = mapsUrl.searchParams.get('query') ?? ''
+  for (const expectedPart of [
+    cinema.name,
+    address.streetAddress,
+    address.postalCode,
+    address.addressLocality,
+    'Netherlands',
+  ]) {
+    if (typeof expectedPart === 'string' && !query.includes(expectedPart)) {
+      failures.push(
+        `${cinema.name}: address.googleMapsUrl query is missing "${expectedPart}"`,
+      )
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(
+    `Cinema data validation failed with ${failures.length} issue(s):`,
+  )
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log(`Validated ${cinemas.length} cinemas.`)

--- a/web/utils/featureFlags.ts
+++ b/web/utils/featureFlags.ts
@@ -1,0 +1,6 @@
+export const isEnabled = (flag: string) =>
+  new Set((process.env.FEATURE_FLAGS ?? '').split(/\s+/).filter(Boolean)).has(
+    flag,
+  )
+
+export const STRUCTURED_DATA_FEATURE = 'structured-data'

--- a/web/utils/getScreenings.ts
+++ b/web/utils/getScreenings.ts
@@ -20,6 +20,7 @@ export type Address = {
   streetAddress: string
   postalCode: string
   addressLocality: string
+  googleMapsUrl: string
 }
 
 export type Cinema = {

--- a/web/utils/getScreenings.ts
+++ b/web/utils/getScreenings.ts
@@ -16,11 +16,18 @@ export type City = {
   slug: string
 }
 
+export type Address = {
+  streetAddress: string
+  postalCode: string
+  addressLocality: string
+}
+
 export type Cinema = {
   name: string
   slug: string
   url: string
   city: City
+  address: Address
   logo?: string
 }
 

--- a/web/utils/jsonLd.ts
+++ b/web/utils/jsonLd.ts
@@ -107,7 +107,6 @@ export const buildScreeningEventJsonLd = (
     offers: {
       '@type': 'Offer',
       url: screening.url,
-      availability: 'https://schema.org/InStock',
     },
     organizer: {
       '@type': 'Organization',

--- a/web/utils/jsonLd.ts
+++ b/web/utils/jsonLd.ts
@@ -1,0 +1,163 @@
+import { getMoviePagePath } from './getMoviePagePath'
+import { getMoviePosterUrl, getMovieReleaseYear, type Movie } from './getMovies'
+import type { Screening } from './getScreenings'
+import { getCanonicalUrl, siteUrl } from './siteUrl'
+
+type JsonLdValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | JsonLdValue[]
+  | { [key: string]: JsonLdValue }
+
+const compactJsonLd = (value: JsonLdValue): JsonLdValue => {
+  if (Array.isArray(value)) {
+    return value
+      .map(compactJsonLd)
+      .filter((item) => item !== undefined && item !== null)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .map(([key, item]) => [key, compactJsonLd(item)] as const)
+        .filter(([, item]) => {
+          if (item === undefined || item === null) {
+            return false
+          }
+
+          return !(Array.isArray(item) && item.length === 0)
+        }),
+    )
+  }
+
+  return value
+}
+
+export const serializeJsonLd = (value: JsonLdValue) =>
+  JSON.stringify(compactJsonLd(value)).replace(/</g, '\\u003c')
+
+export const buildMovieJsonLd = (
+  movie: Movie,
+  movieSlug: string,
+  description?: string,
+) => {
+  const canonicalUrl = getCanonicalUrl(getMoviePagePath(movieSlug))
+  const posterUrl = getMoviePosterUrl(movie.tmdb?.posterPath, 'w342')
+  const year = getMovieReleaseYear(movie)
+
+  return compactJsonLd({
+    '@context': 'https://schema.org',
+    '@type': 'Movie',
+    '@id': `${canonicalUrl}#movie`,
+    name: movie.title,
+    url: canonicalUrl,
+    image: posterUrl,
+    description,
+    datePublished: movie.tmdb?.releaseDate,
+    inLanguage: movie.tmdb?.originalLanguage,
+    duration: movie.tmdb?.runtime ? `PT${movie.tmdb.runtime}M` : undefined,
+    sameAs: [
+      movie.tmdb?.id
+        ? `https://www.themoviedb.org/movie/${movie.tmdb.id}`
+        : undefined,
+      movie.imdbId ? `https://www.imdb.com/title/${movie.imdbId}/` : undefined,
+    ],
+    copyrightYear: year,
+  })
+}
+
+export const buildScreeningEventJsonLd = (
+  movie: Movie,
+  movieSlug: string,
+  screening: Screening,
+) => {
+  const eventUrl = getCanonicalUrl(
+    getMoviePagePath(
+      movieSlug,
+      screening.cinema.city.slug,
+      screening.cinema.slug,
+    ),
+  )
+
+  return compactJsonLd({
+    '@context': 'https://schema.org',
+    '@type': 'Event',
+    name: `${movie.title} at ${screening.cinema.name}`,
+    startDate: screening.date,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    url: eventUrl,
+    image: getMoviePosterUrl(movie.tmdb?.posterPath, 'w342'),
+    location: {
+      '@type': 'MovieTheater',
+      name: screening.cinema.name,
+      url: screening.cinema.url,
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: screening.cinema.city.name,
+        addressCountry: 'NL',
+      },
+    },
+    workFeatured: {
+      '@id': `${getCanonicalUrl(getMoviePagePath(movieSlug))}#movie`,
+    },
+    offers: {
+      '@type': 'Offer',
+      url: screening.url,
+      availability: 'https://schema.org/InStock',
+    },
+    organizer: {
+      '@type': 'Organization',
+      name: screening.cinema.name,
+      url: screening.cinema.url,
+    },
+  })
+}
+
+export const buildBreadcrumbJsonLd = (
+  movie: Movie,
+  movieSlug: string,
+  city?: string,
+  cinema?: string,
+  cityName?: string,
+  cinemaName?: string,
+) => {
+  const items = [
+    {
+      name: 'Expat Cinema',
+      item: siteUrl,
+    },
+    {
+      name: movie.title,
+      item: getCanonicalUrl(getMoviePagePath(movieSlug)),
+    },
+  ]
+
+  if (city && cityName) {
+    items.push({
+      name: cityName,
+      item: getCanonicalUrl(getMoviePagePath(movieSlug, city)),
+    })
+  }
+
+  if (city && cinema && cinemaName) {
+    items.push({
+      name: cinemaName,
+      item: getCanonicalUrl(getMoviePagePath(movieSlug, city, cinema)),
+    })
+  }
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.item,
+    })),
+  }
+}

--- a/web/utils/jsonLd.ts
+++ b/web/utils/jsonLd.ts
@@ -81,6 +81,7 @@ export const buildScreeningEventJsonLd = (
       screening.cinema.slug,
     ),
   )
+  const address = screening.cinema.address
 
   return compactJsonLd({
     '@context': 'https://schema.org',
@@ -97,7 +98,9 @@ export const buildScreeningEventJsonLd = (
       url: screening.cinema.url,
       address: {
         '@type': 'PostalAddress',
-        addressLocality: screening.cinema.city.name,
+        streetAddress: address.streetAddress,
+        postalCode: address.postalCode,
+        addressLocality: address.addressLocality,
         addressCountry: 'NL',
       },
     },

--- a/web/utils/jsonLd.ts
+++ b/web/utils/jsonLd.ts
@@ -96,6 +96,7 @@ export const buildScreeningEventJsonLd = (
       '@type': 'MovieTheater',
       name: screening.cinema.name,
       url: screening.cinema.url,
+      hasMap: address.googleMapsUrl,
       address: {
         '@type': 'PostalAddress',
         streetAddress: address.streetAddress,

--- a/web/utils/seoMetadata.ts
+++ b/web/utils/seoMetadata.ts
@@ -81,3 +81,6 @@ export const buildMovieDescription = (
     overview ? `${overview} ${availability}` : `${movieTitle}: ${availability}`,
   )
 }
+
+export const getMovieDescription = (movieTitle: string, overview?: string) =>
+  truncateDescription(overview ? overview : movieTitle)

--- a/web/utils/seoMetadata.ts
+++ b/web/utils/seoMetadata.ts
@@ -1,22 +1,31 @@
 import type { Screening } from './getScreenings'
 
 export const defaultDescription =
-  'Find foreign-language movie screenings with English subtitles at cinemas across the Netherlands.'
+  'Discover international films with English subtitles playing at cinemas across the Netherlands. Browse showtimes, venues and upcoming screenings.'
 
-const descriptionMaxLength = 155
+const DESCRIPTION_MAXIMUM_LENGTH = 155
 
-export const truncateDescription = (description: string) => {
-  const normalized = description.replace(/\s+/g, ' ').trim()
+const normalizeDescription = (description: string) =>
+  description.replace(/\s+/g, ' ').trim()
 
-  if (normalized.length <= descriptionMaxLength) {
+const truncateDescriptionToLength = (
+  description: string,
+  maximumLength: number,
+) => {
+  const normalized = normalizeDescription(description)
+
+  if (normalized.length <= maximumLength) {
     return normalized
   }
 
-  const truncated = normalized.slice(0, descriptionMaxLength - 1)
+  const truncated = normalized.slice(0, maximumLength - 3)
   const lastSpaceIndex = truncated.lastIndexOf(' ')
 
   return `${truncated.slice(0, lastSpaceIndex > 0 ? lastSpaceIndex : undefined)}...`
 }
+
+export const truncateDescription = (description: string) =>
+  truncateDescriptionToLength(description, DESCRIPTION_MAXIMUM_LENGTH)
 
 export const formatList = (items: string[]) => {
   const uniqueItems = Array.from(new Set(items)).filter(Boolean)
@@ -53,14 +62,14 @@ export const buildCityDescription = (
 
   return truncateDescription(
     cinemaLabel
-      ? `Find English-subtitled movie screenings in ${cityName}, including films at ${cinemaLabel}.`
-      : `Find English-subtitled movie screenings in ${cityName}.`,
+      ? `Discover international films with English subtitles playing at ${cinemaLabel} in ${cityName}.`
+      : `Discover international films with English subtitles playing in ${cityName}.`,
   )
 }
 
 export const buildCinemaDescription = (cinemaName: string, cityName: string) =>
   truncateDescription(
-    `Find English-subtitled movie screenings at ${cinemaName} in ${cityName}, with dates, times, and booking links.`,
+    `Discover international films with English subtitles playing at ${cinemaName} in ${cityName}.`,
   )
 
 export const buildMovieDescription = (
@@ -69,16 +78,26 @@ export const buildMovieDescription = (
   screenings: Screening[],
   locationLabel: string | null,
 ) => {
+  void overview
+
   const cityNames = getScreeningCityNames(screenings, 3)
   const cityLabel = formatList(cityNames)
-  const availability = locationLabel
-    ? `English-subtitled screenings in ${locationLabel}.`
-    : cityLabel
-      ? `English-subtitled screenings in ${cityLabel}.`
-      : 'English-subtitled screenings in the Netherlands.'
+  const location = locationLabel ?? cityLabel ?? 'the Netherlands'
+  const showtimesLabel = locationLabel?.includes(',')
+    ? 'Find showtimes.'
+    : 'Find showtimes and cinemas.'
+  const titleWithoutYear = movieTitle.replace(/\s+\(\d{4}\)$/, '')
+  const descriptions = [
+    `Watch ${movieTitle} with English subtitles in ${location}. ${showtimesLabel}`,
+    `Watch ${titleWithoutYear} with English subtitles in ${location}. ${showtimesLabel}`,
+    `${titleWithoutYear}: English-subtitled screenings in ${location}. ${showtimesLabel}`,
+  ]
+  const description = descriptions.find(
+    (candidate) => candidate.length <= DESCRIPTION_MAXIMUM_LENGTH,
+  )
 
-  return truncateDescription(
-    overview ? `${overview} ${availability}` : `${movieTitle}: ${availability}`,
+  return (
+    description ?? truncateDescription(descriptions[descriptions.length - 1])
   )
 }
 


### PR DESCRIPTION
## Summary
- add reusable JSON-LD helpers for movie, breadcrumb, and screening event schema
- render structured data on movie detail pages, including city/cinema scoped pages
- only emit event markup for valid upcoming screenings to avoid stale event schema

Closes #334

## Validation
- pnpm prettier --write web/components/MoviePage.tsx web/utils/jsonLd.ts web/utils/seoMetadata.ts
- pnpm --dir web exec eslint components/MoviePage.tsx utils/jsonLd.ts utils/seoMetadata.ts
- pnpm --dir web exec tsc --noEmit --pretty false
- pnpm --dir web exec next build
- sampled web/out/movie/exit-8.html for Movie, BreadcrumbList, and non-expired Event JSON-LD