### PR TITLE
Add crawlable intro copy to listing pages

### DIFF
--- a/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
+++ b/web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx
@@ -6,7 +6,10 @@ import cinemas from '../../../../../../data/cinema.json'
 import { getCinema } from '../../../../../../utils/getCinema'
 import { getCity } from '../../../../../../utils/getCity'
 import { getScreenings } from '../../../../../../utils/getScreenings'
-import { buildCinemaDescription } from '../../../../../../utils/seoMetadata'
+import {
+  buildCinemaDescription,
+  buildCinemaIntro,
+} from '../../../../../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../../../../../utils/siteUrl'
 
 export const generateStaticParams = () =>
@@ -40,6 +43,9 @@ export default async function CinemaPage({
   params: Promise<{ city: string; cinema: string }>
 }) {
   const { city, cinema } = await params
+  const cinemaData = getCinema(cinema)
+  const cinemaName = cinemaData?.name ?? cinema
+  const cityName = getCity(cinemaData?.city ?? city)?.name ?? city
   const screenings = (await getScreenings()).filter(
     (screening) =>
       screening.cinema.city.slug === city && screening.cinema.slug === cinema,
@@ -47,7 +53,13 @@ export default async function CinemaPage({
 
   return (
     <Suspense>
-      <App screenings={screenings} currentCity={city} currentCinema={cinema} />
+      <App
+        screenings={screenings}
+        currentCity={city}
+        currentCinema={cinema}
+        title={`English-Subtitled Movies at ${cinemaName}`}
+        intro={buildCinemaIntro(cinemaName, cityName)}
+      />
     </Suspense>
   )
 }

--- a/web/app/(screenings)/city/[city]/page.tsx
+++ b/web/app/(screenings)/city/[city]/page.tsx
@@ -5,7 +5,10 @@ import { App } from '../../../../components/App'
 import cities from '../../../../data/city.json'
 import { getCity } from '../../../../utils/getCity'
 import { getScreenings } from '../../../../utils/getScreenings'
-import { buildCityDescription } from '../../../../utils/seoMetadata'
+import {
+  buildCityDescription,
+  buildCityIntro,
+} from '../../../../utils/seoMetadata'
 import { getCanonicalUrl } from '../../../../utils/siteUrl'
 
 export const generateStaticParams = () =>
@@ -35,13 +38,19 @@ export default async function CityPage({
   params: Promise<{ city: string }>
 }) {
   const { city } = await params
+  const cityName = getCity(city)?.name ?? city
   const screenings = (await getScreenings()).filter(
     (screening) => screening.cinema.city.slug === city,
   )
 
   return (
     <Suspense>
-      <App screenings={screenings} currentCity={city} />
+      <App
+        screenings={screenings}
+        currentCity={city}
+        title={`English-Subtitled Movies in ${cityName}`}
+        intro={buildCityIntro(cityName, screenings)}
+      />
     </Suspense>
   )
 }

--- a/web/components/App.tsx
+++ b/web/components/App.tsx
@@ -1,28 +1,57 @@
 import React from 'react'
 
+import { css } from 'styled-system/css'
+
 import { Screening } from '../utils/getScreenings'
 import { Calendar } from './Calendar'
 import { Layout } from './Layout'
+import { PageTitle } from './PageTitle'
+
+const pageStyle = css({
+  display: 'grid',
+  rowGap: '16px',
+})
+
+const introStyle = css({
+  marginTop: '0',
+  marginBottom: '0',
+  maxWidth: '760px',
+  fontSize: '16px',
+  lineHeight: '1.6',
+  color: 'var(--text-muted-color)',
+})
 
 export const App = ({
   screenings,
   showCity = true,
   currentCity,
   currentCinema,
+  title,
+  intro,
 }: {
   screenings: Screening[]
   showCity?: boolean
   currentCity?: string
   currentCinema?: string
+  title?: string
+  intro?: string
 }) => {
   return (
     <Layout>
-      <Calendar
-        screenings={screenings}
-        showCity={showCity}
-        currentCity={currentCity}
-        currentCinema={currentCinema}
-      />
+      <div className={pageStyle}>
+        {title || intro ? (
+          <div>
+            {title ? <PageTitle>{title}</PageTitle> : null}
+            {intro ? <p className={introStyle}>{intro}</p> : null}
+          </div>
+        ) : null}
+        <Calendar
+          screenings={screenings}
+          showCity={showCity}
+          currentCity={currentCity}
+          currentCinema={currentCinema}
+        />
+      </div>
     </Layout>
   )
 }

--- a/web/utils/seoMetadata.ts
+++ b/web/utils/seoMetadata.ts
@@ -63,6 +63,18 @@ export const buildCinemaDescription = (cinemaName: string, cityName: string) =>
     `Find English-subtitled movie screenings at ${cinemaName} in ${cityName}, with dates, times, and booking links.`,
   )
 
+export const buildCityIntro = (cityName: string, screenings: Screening[]) => {
+  const cinemaNames = getScreeningCinemaNames(screenings)
+  const cinemaLabel = formatList(cinemaNames)
+
+  return cinemaLabel
+    ? `Find English-subtitled movie screenings in ${cityName}, including films at ${cinemaLabel}. Use the listings below to check dates, times, and booking links for foreign-language films with English subtitles.`
+    : `Find English-subtitled movie screenings in ${cityName}. Use the listings below to check dates, times, and booking links for foreign-language films with English subtitles.`
+}
+
+export const buildCinemaIntro = (cinemaName: string, cityName: string) =>
+  `Find English-subtitled movie screenings at ${cinemaName} in ${cityName}. The schedule below lists upcoming foreign-language films with dates, times, and booking links from ${cinemaName}.`
+
 export const buildMovieDescription = (
   movieTitle: string,
   overview: string | undefined,


### PR DESCRIPTION
## Summary
- add optional server-rendered title and intro support to the shared screenings page shell
- render city-specific intro copy from current city screenings
- render cinema-specific intro copy from local cinema and city data

Closes #335

## Validation
- pnpm prettier --write web/components/App.tsx 'web/app/(screenings)/city/[city]/page.tsx' 'web/app/(screenings)/city/[city]/cinema/[cinema]/page.tsx' web/utils/seoMetadata.ts
- pnpm --dir web exec eslint components/App.tsx app/\(screenings\)/city/\[city\]/page.tsx app/\(screenings\)/city/\[city\]/cinema/\[cinema\]/page.tsx utils/seoMetadata.ts
- pnpm --dir web exec tsc --noEmit --pretty false
- pnpm --dir web exec next build
- sampled web/out/city/amsterdam.html and web/out/city/amsterdam/cinema/lab111.html for server-rendered intro copy