### PR TITLE
Improve internal SEO links

### DIFF
--- a/web/app/(screenings)/city/[city]/layout.tsx
+++ b/web/app/(screenings)/city/[city]/layout.tsx
@@ -1,10 +1,26 @@
+import Link from 'next/link'
 import React, { Suspense } from 'react'
+
+import { css } from 'styled-system/css'
 
 import { CinemaFilter } from '../../../../components/CinemaFilter'
 import { FilterLink } from '../../../../components/CityFilter'
 import cinemas from '../../../../data/cinema.json'
+import { getCity } from '../../../../utils/getCity'
 import { getScreenings } from '../../../../utils/getScreenings'
 import { Layout } from '../../../../components/Layout'
+
+const cinemaLinksStyle = css({
+  marginTop: '12px',
+  marginBottom: '0',
+  fontSize: '14px',
+  lineHeight: '1.5',
+  color: 'var(--text-muted-color)',
+})
+
+const cinemaAnchorStyle = css({
+  color: 'var(--secondary-color)',
+})
 
 export default async function CityLayout({
   children,
@@ -15,6 +31,7 @@ export default async function CityLayout({
 }) {
   const { city } = await params
   const screenings = await getScreenings()
+  const cityName = getCity(city)?.name ?? city
 
   const screeningCountByCinema = screenings
     .filter((screening) => screening.cinema.city.slug === city)
@@ -23,20 +40,23 @@ export default async function CityLayout({
       return counts
     }, {})
 
+  const cinemasInCity = cinemas
+    .filter((cinema) => cinema.city === city)
+    .map((cinema) => ({
+      ...cinema,
+      count: screeningCountByCinema[cinema.slug] ?? 0,
+    }))
+    .sort(
+      (left, right) =>
+        right.count - left.count || left.name.localeCompare(right.name),
+    )
+
   const links: FilterLink[] = [
     { text: 'All', slug: null },
-    ...cinemas
-      .filter((cinema) => cinema.city === city)
-      .map(({ name, slug }) => ({
-        text: name,
-        slug,
-        count: screeningCountByCinema[slug] ?? 0,
-      }))
-      .sort(
-        (left, right) =>
-          right.count - left.count || left.text.localeCompare(right.text),
-      )
-      .map(({ text, slug }) => ({ text, slug })),
+    ...cinemasInCity.map(({ name, slug }) => ({
+      text: name,
+      slug,
+    })),
   ]
 
   return (
@@ -46,6 +66,24 @@ export default async function CityLayout({
           <CinemaFilter links={links} />
         </Suspense>
       </Layout>
+      {cinemasInCity.length ? (
+        <Layout>
+          <p className={cinemaLinksStyle}>
+            Browse cinema pages in {cityName}:{' '}
+            {cinemasInCity.map((cinema, index) => (
+              <React.Fragment key={cinema.slug}>
+                <Link
+                  href={`/city/${city}/cinema/${cinema.slug}`}
+                  className={cinemaAnchorStyle}
+                >
+                  English-subtitled movies at {cinema.name}
+                </Link>
+                {index === cinemasInCity.length - 1 ? '' : ', '}
+              </React.Fragment>
+            ))}
+          </p>
+        </Layout>
+      ) : null}
       {children}
     </>
   )

--- a/web/components/About.tsx
+++ b/web/components/About.tsx
@@ -24,6 +24,11 @@ const cityLinkStyle = css({
   textDecoration: 'none',
 })
 
+const cinemaLinkStyle = css({
+  color: 'var(--secondary-color)',
+  fontWeight: '700',
+})
+
 const textLinkStyle = css({
   color: 'var(--secondary-color)',
 })
@@ -76,6 +81,7 @@ export const About = () => {
           <br />
           {citySlugs.map((city) => {
             const href = `/city/${city}`
+            const cityName = getCity(city)?.name ?? city
             const cinemasInCity = cinemas
               .filter((cinema) => cinema.city === city)
               .sort((a, b) => compareAlphabetically(a.name, b.name))
@@ -83,16 +89,29 @@ export const About = () => {
             return (
               <React.Fragment key={city}>
                 <Link href={href} className={cityLinkStyle}>
-                  {getCity(city)?.name ?? city}
+                  English-subtitled movies in {cityName}
                 </Link>
                 :{' '}
                 {cinemasInCity.map((cinema, i, arr) => {
                   const isLast = i === arr.length - 1
                   return (
-                    <React.Fragment key={cinema.url}>
-                      <Link href={cinema.url} className={textLinkStyle}>
-                        {cinema.name}
+                    <React.Fragment key={cinema.slug}>
+                      <Link
+                        href={`/city/${city}/cinema/${cinema.slug}`}
+                        className={cinemaLinkStyle}
+                      >
+                        {cinema.name} screenings
                       </Link>
+                      {' ('}
+                      <Link
+                        href={cinema.url}
+                        className={textLinkStyle}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        cinema website
+                      </Link>
+                      {')'}
                       {isLast ? '' : ', '}
                     </React.Fragment>
                   )


### PR DESCRIPTION
## Summary
- replace About page cinema references with descriptive internal city and cinema page links
- keep external cinema website links available next to each internal cinema link
- add server-rendered city-page cinema links with descriptive anchor text

Closes #338

## Validation
- pnpm prettier --write web/components/About.tsx 'web/app/(screenings)/city/[city]/layout.tsx'
- pnpm --dir web exec eslint components/About.tsx app/\(screenings\)/city/\[city\]/layout.tsx
- pnpm --dir web exec tsc --noEmit --pretty false
- pnpm --dir web exec next build
- sampled web/out/about.html and web/out/city/amsterdam.html for descriptive internal links