### PR TITLE
Noindex low-value statistics page

### DIFF
--- a/web/app/statistics/page.tsx
+++ b/web/app/statistics/page.tsx
@@ -14,6 +14,10 @@ export const metadata: Metadata = {
     'Statistics for Expat Cinema screening coverage, showing scraper activity and collected English-subtitled movie listings.',
   ),
   alternates: { canonical: getCanonicalUrl('/statistics') },
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 export default async function StatisticsPage() {


### PR DESCRIPTION
## Summary
- mark /statistics as noindex, follow because it is utility/coverage reporting rather than a search landing page
- keep /movie/unmatched noindex,nofollow as-is
- leave public discovery pages indexable

Closes #339

## Validation
- pnpm prettier --write web/app/statistics/page.tsx
- pnpm --dir web exec eslint app/statistics/page.tsx
- pnpm --dir web exec tsc --noEmit --pretty false
- pnpm --dir web exec next build
- sampled web/out/statistics.html for noindex, follow
- sampled home, city, and movie exports to confirm no robots noindex meta tag