### PR TITLE
Hide missing screening posters

### DIFF
--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -200,7 +200,7 @@ export const ScreeningRow = ({
             aria-hidden
             className={listPosterStyle}
           />
-        ) : showPoster && movieId ? (
+        ) : showPoster ? (
           <div aria-hidden className={listPosterPlaceholderStyle} />
         ) : null}
       </div>

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -8,7 +8,6 @@ import { Cinema } from '../utils/getScreenings'
 import { getMoviePagePath } from '../utils/getMoviePagePath'
 import { Time } from './Time'
 import {
-  listPosterPlaceholderStyle,
   listPosterStyle,
   listRowBaseStyle,
   listTitleStyle,
@@ -200,8 +199,6 @@ export const ScreeningRow = ({
             aria-hidden
             className={listPosterStyle}
           />
-        ) : showPoster ? (
-          <div aria-hidden className={listPosterPlaceholderStyle} />
         ) : null}
       </div>
     </div>

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -34,9 +34,11 @@ const rowStyle = cx(
       backgroundColor: 'var(--background-highlight-color)',
       borderRadius: '10px',
     },
+    '& .unmatched-movie-poster-placeholder': {
+      backgroundColor: 'var(--background-highlight-color)',
+    },
     '&:hover .unmatched-movie-poster-placeholder': {
-      backgroundColor: 'var(--palette-purple-500)',
-      borderColor: 'var(--palette-purple-500)',
+      backgroundColor: 'var(--palette-purple-300)',
     },
   }),
 )


### PR DESCRIPTION
## Summary
- hide poster placeholders in regular screening rows when no poster is available
- keep placeholders on the unmatched movies page
- update unmatched placeholder colors: default screening-hover background, hover CinemaFilter background

## Data/rendering difference checked
- Soldier's Bones in Leiden is matched to TMDB and has a movieId/movieSlug, but no posterPath/posterUrl
- Don't Expect Too Much from the End of the World at WORM is unmatched and has no movieId/movieSlug/posterUrl
- Regular screening rows now behave consistently: no posterUrl means no poster slot

## Validation
- pnpm --dir web exec eslint components/UnmatchedMoviesOverview.tsx components/Screening.tsx
- pnpm --dir web exec tsc --noEmit --pretty false
- pnpm --dir web exec next build