### PR TITLE
Restore missing screening poster placeholders

### DIFF
--- a/web/components/About.tsx
+++ b/web/components/About.tsx
@@ -89,7 +89,7 @@ export const About = () => {
                 {cinemasInCity.map((cinema, i, arr) => {
                   const isLast = i === arr.length - 1
                   return (
-                    <React.Fragment key={cinema.url}>
+                    <React.Fragment key={cinema.name}>
                       <Link href={cinema.url} className={textLinkStyle}>
                         {cinema.name}
                       </Link>

--- a/web/components/MoviesOverview.tsx
+++ b/web/components/MoviesOverview.tsx
@@ -14,9 +14,9 @@ import {
 } from '../utils/getMovies'
 import { matchesMovieSearch } from '../utils/searchMatches'
 import { Layout } from './Layout'
+import { PosterPlaceholder } from './PosterPlaceholder'
 import {
   listContainerStyle,
-  listPosterPlaceholderStyle,
   listPosterStyle,
   listRowBaseStyle,
   listSectionHeadingStyle,
@@ -90,10 +90,7 @@ export const MovieOverviewRow = ({
           className={listPosterStyle}
         />
       ) : (
-        <div
-          aria-hidden
-          className={cx(listPosterPlaceholderStyle, posterPlaceholderClassName)}
-        />
+        <PosterPlaceholder className={posterPlaceholderClassName} />
       )}
       <div className={listTitleStyle}>
         {movie.title}

--- a/web/components/PosterPlaceholder.tsx
+++ b/web/components/PosterPlaceholder.tsx
@@ -1,0 +1,9 @@
+import { cx } from 'styled-system/css'
+
+import { listPosterPlaceholderStyle } from './listStyles'
+
+export const PosterPlaceholder = ({
+  className,
+}: {
+  className?: string
+}) => <div aria-hidden className={cx(listPosterPlaceholderStyle, className)} />

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -1,14 +1,13 @@
 import { DateTime } from 'luxon'
 import Image from 'next/image'
-import React from 'react'
 
 import { css, cx } from 'styled-system/css'
 
 import { Cinema } from '../utils/getScreenings'
 import { getMoviePagePath } from '../utils/getMoviePagePath'
+import { PosterPlaceholder } from './PosterPlaceholder'
 import { Time } from './Time'
 import {
-  listPosterPlaceholderStyle,
   listPosterStyle,
   listRowBaseStyle,
   listTitleStyle,
@@ -23,12 +22,6 @@ const containerStyle = cx(
     gridTemplateColumns: '[time] 60px [rest] minmax(0, 1fr) [poster] auto',
     gridTemplateRows: 'auto auto',
     gridColumnGap: '12px',
-    '&:hover .screening-poster-placeholder--matched': {
-      backgroundColor: 'var(--palette-purple-300)',
-    },
-    '&:hover .screening-poster-placeholder--unmatched': {
-      backgroundColor: 'var(--background-highlight-color)',
-    },
   }),
 )
 
@@ -92,10 +85,6 @@ const screeningRowLinkStyle = css({
   color: 'var(--text-color)',
 })
 
-const matchedPosterPlaceholderStyle = css({
-  backgroundColor: 'var(--background-highlight-color)',
-})
-
 const unmatchedPosterPlaceholderStyle = css({
   backgroundColor: 'transparent',
 })
@@ -147,105 +136,63 @@ export const ScreeningRow = ({
   showCity?: boolean
   showPoster?: boolean
 }) => {
-  const movieIdClassName = movieId
-    ? `movie-id-${movieId.replace(/[^a-zA-Z0-9_-]/g, '-')}`
-    : undefined
-  const tmdbUrl = movieId?.startsWith('tmdb:')
-    ? `https://www.themoviedb.org/movie/${movieId.slice(5)}`
-    : undefined
   const movieUrl =
     movieHref ?? (movieSlug ? getMoviePagePath(movieSlug) : undefined)
-  const hasMovieMetadata = Boolean(movieId)
-  const posterPlaceholder = (
-    <div
-      aria-hidden
-      className={cx(
-        listPosterPlaceholderStyle,
-        hasMovieMetadata
-          ? matchedPosterPlaceholderStyle
-          : unmatchedPosterPlaceholderStyle,
-        hasMovieMetadata
-          ? 'screening-poster-placeholder--matched'
-          : 'screening-poster-placeholder--unmatched',
-      )}
-    />
-  )
 
   return (
-    <div className={movieIdClassName}>
-      <div className={containerStyle}>
-        <a
-          href={url}
-          aria-label={`Open screening for ${title}`}
-          className={screeningRowLinkStyle}
-        />
-        <div className={timeStyle}>
-          <Time>{date}</Time>
-        </div>
-        <div className={contentStyle}>
-          <div className={listTitleStyle} style={{ pointerEvents: 'none' }}>
-            {title}
-            {year ? <span className={listYearStyle}> ({year})</span> : null}
-          </div>
-          <div className={cinemaInfoStyle}>
-            <CinemaIcon cinema={cinema} />
-            {cinema.name}
-            {showCity ? <> | {cinema.city.name}</> : null}
-          </div>
-        </div>
-        {showPoster && posterUrl && movieUrl ? (
-          <a href={movieUrl} className={posterLinkStyle}>
-            <Image
-              src={posterUrl}
-              width={48}
-              height={72}
-              alt=""
-              aria-hidden
-              className={listPosterStyle}
-            />
-          </a>
-        ) : showPoster && posterUrl && tmdbUrl ? (
-          <a
-            href={tmdbUrl}
-            target="_blank"
-            rel="noreferrer"
-            className={posterLinkStyle}
-          >
-            <Image
-              src={posterUrl}
-              width={48}
-              height={72}
-              alt=""
-              aria-hidden
-              className={listPosterStyle}
-            />
-          </a>
-        ) : showPoster && posterUrl ? (
-          <Image
-            src={posterUrl}
-            width={48}
-            height={72}
-            alt=""
-            aria-hidden
-            className={listPosterStyle}
-          />
-        ) : showPoster && movieUrl ? (
-          <a href={movieUrl} className={posterLinkStyle}>
-            {posterPlaceholder}
-          </a>
-        ) : showPoster && tmdbUrl ? (
-          <a
-            href={tmdbUrl}
-            target="_blank"
-            rel="noreferrer"
-            className={posterLinkStyle}
-          >
-            {posterPlaceholder}
-          </a>
-        ) : showPoster ? (
-          posterPlaceholder
-        ) : null}
+    <div className={containerStyle}>
+      <a
+        href={url}
+        aria-label={`Open screening for ${title}`}
+        className={screeningRowLinkStyle}
+      />
+      <div className={timeStyle}>
+        <Time>{date}</Time>
       </div>
+      <div className={contentStyle}>
+        <div className={listTitleStyle} style={{ pointerEvents: 'none' }}>
+          {title}
+          {year ? <span className={listYearStyle}> ({year})</span> : null}
+        </div>
+        <div className={cinemaInfoStyle}>
+          <CinemaIcon cinema={cinema} />
+          {cinema.name}
+          {showCity ? <> | {cinema.city.name}</> : null}
+        </div>
+      </div>
+      {showPoster ? (
+        posterUrl ? (
+          movieUrl ? (
+            <a href={movieUrl} className={posterLinkStyle}>
+              <Image
+                src={posterUrl}
+                width={48}
+                height={72}
+                alt=""
+                aria-hidden
+                className={listPosterStyle}
+              />
+            </a>
+          ) : (
+            <Image
+              src={posterUrl}
+              width={48}
+              height={72}
+              alt=""
+              aria-hidden
+              className={listPosterStyle}
+            />
+          )
+        ) : movieUrl ? (
+          <a href={movieUrl} className={posterLinkStyle}>
+            <PosterPlaceholder
+              className={
+                movieId ? undefined : unmatchedPosterPlaceholderStyle
+              }
+            />
+          </a>
+        ) : null
+      ) : null}
     </div>
   )
 }

--- a/web/components/Screening.tsx
+++ b/web/components/Screening.tsx
@@ -8,6 +8,7 @@ import { Cinema } from '../utils/getScreenings'
 import { getMoviePagePath } from '../utils/getMoviePagePath'
 import { Time } from './Time'
 import {
+  listPosterPlaceholderStyle,
   listPosterStyle,
   listRowBaseStyle,
   listTitleStyle,
@@ -22,6 +23,12 @@ const containerStyle = cx(
     gridTemplateColumns: '[time] 60px [rest] minmax(0, 1fr) [poster] auto',
     gridTemplateRows: 'auto auto',
     gridColumnGap: '12px',
+    '&:hover .screening-poster-placeholder--matched': {
+      backgroundColor: 'var(--palette-purple-300)',
+    },
+    '&:hover .screening-poster-placeholder--unmatched': {
+      backgroundColor: 'var(--background-highlight-color)',
+    },
   }),
 )
 
@@ -85,6 +92,14 @@ const screeningRowLinkStyle = css({
   color: 'var(--text-color)',
 })
 
+const matchedPosterPlaceholderStyle = css({
+  backgroundColor: 'var(--background-highlight-color)',
+})
+
+const unmatchedPosterPlaceholderStyle = css({
+  backgroundColor: 'transparent',
+})
+
 type CinemaIconProps = {
   cinema: Cinema
 }
@@ -140,6 +155,21 @@ export const ScreeningRow = ({
     : undefined
   const movieUrl =
     movieHref ?? (movieSlug ? getMoviePagePath(movieSlug) : undefined)
+  const hasMovieMetadata = Boolean(movieId)
+  const posterPlaceholder = (
+    <div
+      aria-hidden
+      className={cx(
+        listPosterPlaceholderStyle,
+        hasMovieMetadata
+          ? matchedPosterPlaceholderStyle
+          : unmatchedPosterPlaceholderStyle,
+        hasMovieMetadata
+          ? 'screening-poster-placeholder--matched'
+          : 'screening-poster-placeholder--unmatched',
+      )}
+    />
+  )
 
   return (
     <div className={movieIdClassName}>
@@ -199,6 +229,21 @@ export const ScreeningRow = ({
             aria-hidden
             className={listPosterStyle}
           />
+        ) : showPoster && movieUrl ? (
+          <a href={movieUrl} className={posterLinkStyle}>
+            {posterPlaceholder}
+          </a>
+        ) : showPoster && tmdbUrl ? (
+          <a
+            href={tmdbUrl}
+            target="_blank"
+            rel="noreferrer"
+            className={posterLinkStyle}
+          >
+            {posterPlaceholder}
+          </a>
+        ) : showPoster ? (
+          posterPlaceholder
         ) : null}
       </div>
     </div>

--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -37,9 +37,6 @@ const rowStyle = cx(
     '& .unmatched-movie-poster-placeholder': {
       backgroundColor: 'var(--background-highlight-color)',
     },
-    '&:hover .unmatched-movie-poster-placeholder': {
-      backgroundColor: 'var(--palette-purple-300)',
-    },
   }),
 )
 


### PR DESCRIPTION
## Summary
- Render a placeholder whenever a screening row is missing a poster.
- Keep matched/TMDB screenings clickable to their movie page or TMDB fallback, using pink to darker-pink placeholder states.
- Keep unmatched/no-TMDB screenings non-clickable, using transparent to pink placeholder states.

## Validation
- pnpm --dir web exec eslint components/Screening.tsx
- pnpm --dir web exec tsc --noEmit --pretty false
- pnpm --dir web build

## Data check
- Soldier's Bones at Kijkhuis has movieId tmdb:1638209, movieSlug soldier-s-bones, and no posterUrl, so it now gets a clickable matched placeholder.
- Unmatched screenings with no movieId and no posterUrl still get a placeholder, but without a movie-page link.