### PR TITLE
Show unmatched movie count in page heading

### DIFF
--- a/web/components/UnmatchedMoviesOverview.tsx
+++ b/web/components/UnmatchedMoviesOverview.tsx
@@ -122,7 +122,7 @@ export const UnmatchedMoviesOverview = ({
     <Layout>
       <div className={pageStyle}>
         <div>
-          <PageTitle>Unmatched movies</PageTitle>
+          <PageTitle>Unmatched movies ({uniqueUnmatchedMovies.length})</PageTitle>
           <p className={introStyle}>
             All movies that couldn't be matched to a known movie in The Movie
             Database.


### PR DESCRIPTION
## Summary

- Adds the total number of deduplicated unmatched movies in parentheses after the `<h1>` on `/movie/unmatched` (e.g. "Unmatched movies (50)")
- Count uses the already-computed `uniqueUnmatchedMovies` array, so it reflects the true deduplicated total regardless of any active search filter

## Test plan

- [ ] Visit `/movie/unmatched` and confirm the heading shows a count in parentheses
- [ ] Confirm the count matches the number of movies listed on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)