### PR TITLE
Add Subtitles: English metadata row to movie pages

### DIFF
--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -319,20 +319,19 @@ export const MoviePage = ({
                 {originalTitle}
               </p>
             ) : null}
-            {description || originalLanguage || runtime || genres || voteAverage || directors ? (
-              <div className={detailsStyle}>
-                {description ? (
-                  <p className={descriptionStyle}>{description}</p>
-                ) : null}
-                <div className={metadataStyle}>
-                  <MetadataRow label="Director" value={directors} />
-                  <MetadataRow label="Genre" value={genres} />
-                  <MetadataRow label="Language" value={originalLanguage} />
-                  <MetadataRow label="Runtime" value={runtime} />
-                  <MetadataRow label="Rating" value={voteAverage ? `${voteAverage}/10` : undefined} />
-                </div>
+            <div className={detailsStyle}>
+              {description ? (
+                <p className={descriptionStyle}>{description}</p>
+              ) : null}
+              <div className={metadataStyle}>
+                <MetadataRow label="Director" value={directors} />
+                <MetadataRow label="Genre" value={genres} />
+                <MetadataRow label="Language" value={originalLanguage} />
+                <MetadataRow label="Subtitles" value="English" />
+                <MetadataRow label="Runtime" value={runtime} />
+                <MetadataRow label="Rating" value={voteAverage ? `${voteAverage}/10` : undefined} />
               </div>
-            ) : null}
+            </div>
             <div className={linkRowStyle}>
               {tmdbHref ? (
                 <a


### PR DESCRIPTION
## Summary

- Adds a fixed **Subtitles: English** metadata row to every movie page, positioned between Language and Runtime
- Since the site exclusively shows screenings with English subtitles, this is a hardcoded value

## Test plan

- [ ] Visit any movie page and confirm "Subtitles: English" appears in the metadata section
- [ ] Check it renders correctly on both movies with and without other metadata fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)