### PR TITLE
Style TMDB/IMDb as underlined links with SVG external link icon

### DIFF
--- a/web/components/MoviePage.tsx
+++ b/web/components/MoviePage.tsx
@@ -125,11 +125,26 @@ const linkRowStyle = css({
 const externalLinkStyle = css({
   fontSize: '14px',
   color: 'var(--secondary-color)',
-  textDecoration: 'none',
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
   '&:hover': {
-    textDecoration: 'underline',
+    opacity: '0.75',
   },
 })
+
+const ExternalLinkIcon = () => (
+  <svg
+    width="11"
+    height="11"
+    viewBox="0 0 11 11"
+    fill="currentColor"
+    style={{ display: 'inline', verticalAlign: 'middle', marginLeft: '2px' }}
+    aria-hidden="true"
+  >
+    <path d="M0 1.5A1.5 1.5 0 011.5 0H5v1.5H1.5v8h8V6H11v3.5A1.5 1.5 0 019.5 11h-8A1.5 1.5 0 010 9.5v-8z" />
+    <path d="M6.5 0H11v4.5H9.5V2.56L5.03 7.03 3.97 5.97 8.44 1.5H6.5V0z" />
+  </svg>
+)
 
 const trailerSectionStyle = css({
   display: 'grid',
@@ -341,7 +356,7 @@ export const MoviePage = ({
                   rel="noreferrer"
                   className={externalLinkStyle}
                 >
-                  TMDB
+                  TMDB <ExternalLinkIcon />
                 </a>
               ) : null}
               {imdbHref ? (
@@ -351,7 +366,7 @@ export const MoviePage = ({
                   rel="noreferrer"
                   className={externalLinkStyle}
                 >
-                  IMDb
+                  IMDb <ExternalLinkIcon />
                 </a>
               ) : null}
             </div>


### PR DESCRIPTION
## Summary

- Replaces plain text "TMDB" / "IMDb" with underlined purple links
- Adds inline SVG external link icon (classic box-with-arrow) instead of ↗ arrow character
- Addresses design review finding #11: links were reading as inline body text, not navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)