### PR TITLE
Add full date to Today/Tomorrow calendar headings

### DIFF
--- a/web/components/RelativeDate.tsx
+++ b/web/components/RelativeDate.tsx
@@ -11,11 +11,12 @@ export const RelativeDate = ({ children }: { children: string }) => {
 
   const diff = date.diff(today, 'days').days
 
-  let relativeDate = date.toFormat('EEEE d MMMM')
+  const fullDate = date.toFormat('EEEE d MMMM')
+  let relativeDate = fullDate
   if (diff === 0) {
-    relativeDate = 'Today'
+    relativeDate = `Today \u2013 ${fullDate}`
   } else if (diff === 1) {
-    relativeDate = 'Tomorrow'
+    relativeDate = `Tomorrow \u2013 ${fullDate}`
   }
 
   return <h3 className={listSectionHeadingStyle}>{relativeDate}</h3>


### PR DESCRIPTION
## Summary

- "Today" → "Today – Wednesday 6 May"
- "Tomorrow" → "Tomorrow – Thursday 7 May"
- Other dates unchanged (e.g. "Friday 8 May")

Addresses design review finding #13. Verified on mobile (375px) — fits on one line without wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)