### PR TITLE
Separate operational logs from observational diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ cd cloud
 pnpm tsx scrapers/<name>.ts
 ```
 
-If needed, add `LOG_LEVEL=debug` to inspect the upstream payload and returned screenings.
+Add `POWERTOOLS_LOG_LEVEL=DEBUG` to see intermediate scraping data (raw page contents, per-URL extraction steps, etc.).
 
 ### FK-feed year notes
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,13 @@ if (require.main === module) {
 }
 ```
 
-Add `POWERTOOLS_LOG_LEVEL=DEBUG` to see intermediate scraping data (raw page contents, per-URL extraction steps, etc.)
+To see intermediate scraping data (raw page contents, per-URL extraction steps, etc.), add `POWERTOOLS_LOG_LEVEL=DEBUG` on the command line:
+
+```sh
+POWERTOOLS_LOG_LEVEL=DEBUG pnpm tsx scrapers/kinorotterdam.ts
+```
+
+Or set it in `.env.local` when using `pnpm run scrapers:local`.
 
 ## Quick local backup
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Use the `SCRAPERS` environment variable in `.env.local` to define a comma separa
 
 ### Single scraper
 
-And to call a single scraper, e.g. `LOG_LEVEL=debug pnpm tsx scrapers/kinorotterdam.ts` and then have e.g.
+And to call a single scraper, e.g. `pnpm tsx scrapers/kinorotterdam.ts` and then have e.g.
 
 ```
 if (require.main === module) {
@@ -82,7 +82,7 @@ if (require.main === module) {
 }
 ```
 
-with the LOG_LEVEL=debug used to have debug output from the scrapers show up in the console
+Add `POWERTOOLS_LOG_LEVEL=DEBUG` to see intermediate scraping data (raw page contents, per-URL extraction steps, etc.)
 
 ## Quick local backup
 

--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -4,4 +4,4 @@ OMDB_API_KEY=
 GOOGLE_CUSTOM_SEARCH_API_KEY=
 GOOGLE_CUSTOM_SEARCH_ID=
 SCRAPERS=
-# POWERTOOLS_LOG_LEVEL=DEBUG  # uncomment to see intermediate scraping data in scrapers:local output
+POWERTOOLS_LOG_LEVEL=DEBUG  # to see debugging output and scraping data in scrapers:local output

--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -4,3 +4,4 @@ OMDB_API_KEY=
 GOOGLE_CUSTOM_SEARCH_API_KEY=
 GOOGLE_CUSTOM_SEARCH_ID=
 SCRAPERS=
+# POWERTOOLS_LOG_LEVEL=DEBUG  # uncomment to see intermediate scraping data in scrapers:local output

--- a/cloud/browser.ts
+++ b/cloud/browser.ts
@@ -16,7 +16,7 @@ const createBrowserSingleton = () => {
 
   const initializeBrowser = async ({ logger }: { logger?: Logger }) => {
     try {
-      logger?.info('running locally?', { isLocal: process.env.IS_LOCAL })
+      logger?.debug('running locally?', { isLocal: process.env.IS_LOCAL })
 
       const chromiumOptions = chromium as typeof chromium & {
         defaultViewport?: LaunchOptions['defaultViewport']
@@ -33,9 +33,9 @@ const createBrowserSingleton = () => {
         acceptInsecureCerts: true,
       }
 
-      logger?.info('launching browser', { options })
+      logger?.debug('launching browser', { options })
       instance = await puppeteer.launch(options)
-      logger?.info('browser launched')
+      logger?.debug('browser launched')
     } catch (error) {
       instance = undefined
       throw error
@@ -44,7 +44,7 @@ const createBrowserSingleton = () => {
 
       const pendingRequests = initializationQueue.splice(0)
       pendingRequests.forEach(({ resolve, reject }, index) => {
-        logger?.info('settling pending browser initialization request', {
+        logger?.debug('settling pending browser initialization request', {
           index,
           hasInstance: Boolean(instance),
         })
@@ -60,19 +60,19 @@ const createBrowserSingleton = () => {
 
   return async ({ logger }: { logger?: Logger }): Promise<Browser> => {
     if (!instance && !isInitializing) {
-      logger?.info('initializing browser')
+      logger?.debug('initializing browser')
       isInitializing = true
       await initializeBrowser({ logger })
     }
 
     if (isInitializing) {
-      logger?.info('browser is initializing')
+      logger?.debug('browser is initializing')
       // If initialization is in progress, return a promise that settles when it's done
       return new Promise<Browser>((resolve, reject) => {
         initializationQueue.push({ resolve, reject })
       })
     } else {
-      logger?.info('browser is initialized')
+      logger?.debug('browser is initialized')
       // If instance is available, return it
       if (!instance) {
         throw new Error('browser failed to initialize')
@@ -98,21 +98,21 @@ const closePagesAndBrowser = async ({
   logger?: Logger
 }) => {
   const pages = await browser.pages()
-  logger?.info('closing pages', { numberOfPages: pages.length })
+  logger?.debug('closing pages', { numberOfPages: pages.length })
   await Promise.all(pages.map((p) => p.close()))
 
-  logger?.info('closing browser')
+  logger?.debug('closing browser')
   await browser.close()
-  logger?.info('done closing browser')
+  logger?.debug('done closing browser')
 }
 
 export const closeBrowser = async ({ logger }: { logger?: Logger }) => {
   const browser = await getBrowser({ logger })
 
   const connected = browser.isConnected()
-  logger?.info('is browser connected', { connected })
+  logger?.debug('is browser connected', { connected })
   if (connected) {
-    logger?.info('closing pages and browser')
+    logger?.debug('closing pages and browser')
 
     try {
       await Promise.race([

--- a/cloud/lib/config.ts
+++ b/cloud/lib/config.ts
@@ -14,7 +14,5 @@ export const getConfig = (): ConfigProps => {
     SCRAPERS: process.env.SCRAPERS || '',
     SCRAPEOPS_API_KEY: process.env.SCRAPEOPS_API_KEY || '',
   }
-  // console.log('⚙️', { config })
-
   return config
 }

--- a/cloud/metadata/searchMetadata.ts
+++ b/cloud/metadata/searchMetadata.ts
@@ -188,7 +188,7 @@ const searchMetadata = async (
   const bestCandidate = bestCandidateSelection?.winner
   const secondCandidate = scoredCandidates[1]
 
-  logger.info('searchMetadata scored candidates', {
+  logger.debug('searchMetadata scored candidates', {
     normalizedTitle,
     year,
     siblingYearHints,

--- a/cloud/scrapers/amstelveen.ts
+++ b/cloud/scrapers/amstelveen.ts
@@ -41,7 +41,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     },
   ).json()
 
-  logger.info('api response', { numberOfShows: apiResponse.Data.length })
+  logger.debug('api response', { numberOfShows: apiResponse.Data.length })
 
   const screenings = apiResponse.Data.filter(hasEnglishSubtitles).map((show) => ({
     title: titleCase(show.Production.Title),

--- a/cloud/scrapers/bioscopenleiden.ts
+++ b/cloud/scrapers/bioscopenleiden.ts
@@ -62,7 +62,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     await got('https://bioscopenleiden.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -87,7 +87,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/chasse.ts
+++ b/cloud/scrapers/chasse.ts
@@ -68,7 +68,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     },
   ])
 
-  logger.info('main page', { results })
+  logger.debug('main page', { results })
 
   const screenings = results
     .filter(({ title }) => title?.toLowerCase().includes('en subs'))

--- a/cloud/scrapers/cinecenter.ts
+++ b/cloud/scrapers/cinecenter.ts
@@ -49,7 +49,7 @@ type CinecenterProduction = {
 }
 
 const extractFromMainPage = async (): Promise<Screening[]> => {
-  logger.info('extracting main page')
+  logger.debug('extracting main page')
 
   const html = await got('https://cinecenter.nl/films/').text()
 
@@ -63,7 +63,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const props = JSON.parse(propsStr)
   const productions = decodeAstro(props.productions) as CinecenterProduction[]
 
-  logger.info('productions found', { count: productions.length })
+  logger.debug('productions found', { count: productions.length })
 
   const screenings: Screening[] = productions
     .filter((p) => p.tags.some((t) => t.name === ENG_SUBS_TAG_NAME))
@@ -81,7 +81,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       }))
     })
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/cinecitta.ts
+++ b/cloud/scrapers/cinecitta.ts
@@ -67,11 +67,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       },
     ).json()
 
-    logger.info('movies found', { movies })
+    logger.debug('movies found', { movies })
 
     const moviesWithEnglishSubtitles = movies.filter(hasEnglishSubtitles)
 
-    logger.info('movies with english subtitles', { moviesWithEnglishSubtitles })
+    logger.debug('movies with english subtitles', { moviesWithEnglishSubtitles })
 
     const screenings: Screening[][] = (
       await Promise.all(
@@ -98,7 +98,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       )
     ).filter((x) => x)
 
-    logger.info('before flatten', { screenings })
+    logger.debug('before flatten', { screenings })
 
     return screenings.flat()
   } catch (error) {

--- a/cloud/scrapers/cinemadevlugt.ts
+++ b/cloud/scrapers/cinemadevlugt.ts
@@ -75,7 +75,7 @@ const extractFromMoviePage = async ({
     ]),
   })
 
-  logger.info('extractFromMoviePage', { url, movie })
+  logger.debug('extractFromMoviePage', { url, movie })
 
   return makeScreeningsUniqueAndSorted(
     (movie.screenings ?? []).map(({ date, time }) => ({
@@ -99,13 +99,13 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings = (
     await Promise.all(movies.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('screenings found', { count: screenings.length, screenings })
+  logger.debug('screenings found', { count: screenings.length, screenings })
 
   return screenings
 }

--- a/cloud/scrapers/cinerama.ts
+++ b/cloud/scrapers/cinerama.ts
@@ -73,7 +73,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     const moviesWithEnglishSubtitles =
       programmation.films.filter(hasEnglishSubtitles)
 
-    logger.info('movies with english subtitles', { moviesWithEnglishSubtitles })
+    logger.debug('movies with english subtitles', { moviesWithEnglishSubtitles })
 
     const screenings: Screening[][] = moviesWithEnglishSubtitles.map((movie) =>
       programmation.sessions
@@ -86,7 +86,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
         })),
     )
 
-    logger.info('before flatten', { screenings })
+    logger.debug('before flatten', { screenings })
 
     return screenings.flat()
   } catch (error) {

--- a/cloud/scrapers/concordia.ts
+++ b/cloud/scrapers/concordia.ts
@@ -41,7 +41,7 @@ const parseDate = (date: string) => {
 }
 
 const extractFromMainPage = async (): Promise<Screening[]> => {
-  logger.info('extracting main page')
+  logger.debug('extracting main page')
 
   const results: XRayScreening[] = await xray(
     'https://www.concordia.nl/eng-subs',
@@ -56,7 +56,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { results })
+  logger.debug('main page', { results })
 
   if (results.length === 0) {
     logger.error('No screenings found on main page, scraper is probably broken')
@@ -86,7 +86,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       })
     })
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/defilmhallen.ts
+++ b/cloud/scrapers/defilmhallen.ts
@@ -51,7 +51,7 @@ const extractFromMainPage = async () => {
     await got('https://filmhallen.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -69,7 +69,7 @@ const extractFromMainPage = async () => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/desien.ts
+++ b/cloud/scrapers/desien.ts
@@ -65,7 +65,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { results })
+  logger.debug('main page', { results })
 
   const screenings = results
     .filter(

--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -81,7 +81,7 @@ type XRayFromMoviePage = {
 export const extractFromMoviePage = async (
   url: string,
 ): Promise<Screening[]> => {
-  logger.info('extracting', { url })
+  logger.debug('extracting', { url })
 
   const movie: XRayFromMoviePage = await xray(url, {
     title: 'h1.title',
@@ -89,7 +89,7 @@ export const extractFromMoviePage = async (
     screenings: ['.film-tickets a@data-date'],
   })
 
-  logger.info('extracted xray', { url, movie })
+  logger.debug('extracted xray', { url, movie })
 
   if (!hasEnglishSubtitles(movie)) return []
 
@@ -104,7 +104,7 @@ export const extractFromMoviePage = async (
     }
   })
 
-  logger.info('extracting done', { url, screenings })
+  logger.debug('extracting done', { url, screenings })
 
   return screenings
 }
@@ -115,7 +115,7 @@ type XRayFromMainPage = {
 }
 
 const extractFromMainPage = async () => {
-  logger.info('extracting main page')
+  logger.debug('extracting main page')
 
   const xrayResult: XRayFromMainPage[] = await xray(
     'https://uitkijk.nl/',
@@ -130,11 +130,11 @@ const extractFromMainPage = async () => {
 
   const uniqueUrls = Array.from(new Set(xrayResult.map((x) => x.url)))
 
-  logger.info('main page', { uniqueUrls })
+  logger.debug('main page', { uniqueUrls })
 
   const screenings = await Promise.all(uniqueUrls.map(extractFromMoviePage))
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/dewittdordrecht.ts
+++ b/cloud/scrapers/dewittdordrecht.ts
@@ -78,7 +78,7 @@ const extractFromMoviePage = async ({
     ]),
   })
 
-  logger.info('movie page', { url, movie })
+  logger.debug('movie page', { url, movie })
 
   return makeScreeningsUniqueAndSorted(
     movie.screenings.flatMap(({ date, times }) =>
@@ -104,7 +104,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { results })
+  logger.debug('main page', { results })
 
   const expatCinemaPages = results
     .filter(({ title }) => title?.toLowerCase().includes('expat cinema'))

--- a/cloud/scrapers/dokhuis.ts
+++ b/cloud/scrapers/dokhuis.ts
@@ -39,7 +39,7 @@ const extractFromMoviePage = async ({
     time: '.information-container .time',
   })
 
-  logger.info('scrapeResult', { scrapeResult })
+  logger.debug('scrapeResult', { scrapeResult })
 
   const { content, date, time } = scrapeResult
 
@@ -73,7 +73,7 @@ const extractFromMoviePage = async ({
     }).toJSDate(),
   }
 
-  logger.info('extracted screening', { screening })
+  logger.debug('extracted screening', { screening })
 
   return [screening]
 }
@@ -98,13 +98,13 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       title.toLowerCase().includes('movie night: acts of care'),
     ) // only events with "Movie Night: Acts of care" in the title have English subtitles
 
-  logger.info('extracted', { movies })
+  logger.debug('extracted', { movies })
 
   const screenings = (
     await Promise.all(movies.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/eyefilm.ts
+++ b/cloud/scrapers/eyefilm.ts
@@ -89,7 +89,7 @@ const extractFromGraphQL = async (): Promise<Screening[]> => {
 
   const shows = results.data?.shows ?? []
 
-  logger.info('number of shows', { count: shows.length })
+  logger.debug('number of shows', { count: shows.length })
 
   const screenings = shows
     .filter(hasEnglishSubtitles)

--- a/cloud/scrapers/fchyena.ts
+++ b/cloud/scrapers/fchyena.ts
@@ -103,7 +103,7 @@ const extractFromTicketPage = async ({
     },
   ])
 
-  logger.info('ticket page', { title, productionId, screenings })
+  logger.debug('ticket page', { title, productionId, screenings })
 
   return screenings.map(({ date }) => ({
     title,
@@ -121,7 +121,7 @@ const extractFromMoviePage = async (
     credits: ['.film-detail__credits div | normalizeWhitespace | trim'],
   })
 
-  logger.info('detail page', { movie, detailPage })
+  logger.debug('detail page', { movie, detailPage })
 
   if (!hasEnglishSubtitles(detailPage)) {
     return []
@@ -148,7 +148,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { results })
+  logger.debug('main page', { results })
 
   const screenings = (
     await Promise.all(

--- a/cloud/scrapers/filmhuisdenhaag.ts
+++ b/cloud/scrapers/filmhuisdenhaag.ts
@@ -135,7 +135,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     'https://filmhuisdenhaag.nl/api/program',
   ).json()
 
-  logger.info('extracted api response', { apiResponse })
+  logger.debug('extracted api response', { apiResponse })
 
   // make a flat list of all screenings
   const programs = Object.values(apiResponse)
@@ -190,7 +190,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
   const uniqueSortedScreenings = makeScreeningsUniqueAndSorted(screenings)
 
-  logger.info('extracted screenings', { screenings: uniqueSortedScreenings })
+  logger.debug('extracted screenings', { screenings: uniqueSortedScreenings })
   return uniqueSortedScreenings
 }
 

--- a/cloud/scrapers/filmhuislumen.ts
+++ b/cloud/scrapers/filmhuislumen.ts
@@ -106,7 +106,7 @@ const extractFromMoviePage = async ({
     ]),
   })
 
-  logger.info('extractFromMoviePage', { movie })
+  logger.debug('extractFromMoviePage', { movie })
 
   if (!hasEnglishSubtitles(movie)) {
     return []
@@ -177,13 +177,13 @@ const extractFromMainPage = async () => {
       item.url && index === self.findIndex((t) => t.url === item.url),
   )
 
-  logger.info('scrape result', { scrapeResult })
+  logger.debug('scrape result', { scrapeResult })
 
   const screenings: Screening[] = (
     await Promise.all(scrapeResult.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('screenings found', { screenings })
+  logger.debug('screenings found', { screenings })
 
   return makeScreeningsUniqueAndSorted(screenings)
 }

--- a/cloud/scrapers/filmkoepel.ts
+++ b/cloud/scrapers/filmkoepel.ts
@@ -48,7 +48,7 @@ const extractFromSpecialExpatCinemaPage = async () => {
     },
   ])
 
-  logger.info('special expat cinema page', { movies })
+  logger.debug('special expat cinema page', { movies })
 
   const screenings: Screening[] = movies.flatMap(
     ({ title, url, screenings }) => {
@@ -108,7 +108,7 @@ const extractFromSpecialExpatCinemaPage = async () => {
     },
   )
 
-  logger.info('main page', { screenings })
+  logger.debug('main page', { screenings })
 
   return screenings
 }
@@ -144,7 +144,7 @@ const extractFromMainPage = async () => {
     await got('https://filmkoepel.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -162,7 +162,7 @@ const extractFromMainPage = async () => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   const allScreenings = [...specialExpatScreenings, ...screenings.flat()]
 

--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -144,7 +144,7 @@ const extractFromMoviePage = async ({
     ]),
   })
 
-  logger.info('movie page', { title, url, detailPage })
+  logger.debug('movie page', { title, url, detailPage })
 
   if (!hasEnglishSubtitles(detailPage)) {
     return []
@@ -177,7 +177,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     },
   ])
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings = (
     await Promise.all(

--- a/cloud/scrapers/florafilmtheater.ts
+++ b/cloud/scrapers/florafilmtheater.ts
@@ -108,7 +108,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       },
     ])
 
-    logger.info('movies', { movies })
+    logger.debug('movies', { movies })
 
     const moviesWithEnglishSubtitles = movies.filter(hasEnglishSubtitles)
 
@@ -117,7 +117,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       return []
     }
 
-    logger.info('movies', { moviesWithEnglishSubtitles })
+    logger.debug('movies', { moviesWithEnglishSubtitles })
 
     const screenings: Screening[] = moviesWithEnglishSubtitles.flatMap(
       (movie) => {
@@ -148,7 +148,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       },
     )
 
-    logger.info('screenings', { screenings })
+    logger.debug('screenings', { screenings })
 
     return screenings
   } catch (error) {

--- a/cloud/scrapers/focusarnhem.ts
+++ b/cloud/scrapers/focusarnhem.ts
@@ -96,7 +96,7 @@ const splitDate = (date: string) => {
 }
 
 const extractFromMoviePage = async (url: string): Promise<Screening[]> => {
-  logger.info('extracting', { url })
+  logger.debug('extracting', { url })
 
   const movie: XRayFromMoviePage = await xray(url, {
     title: 'h1 | trim | cleanTitle',
@@ -109,7 +109,7 @@ const extractFromMoviePage = async (url: string): Promise<Screening[]> => {
     ]),
   })
 
-  logger.info('extractFromMoviePage', { movie })
+  logger.debug('extractFromMoviePage', { movie })
 
   if (!hasEnglishSubtitles(movie)) {
     logger.warn('extractFromMoviePage without english subtitles', {
@@ -159,13 +159,13 @@ const extractFromMainPage = async () => {
     ],
   )
 
-  logger.info('movies', { movies })
+  logger.debug('movies', { movies })
 
   const screenings = (
     await Promise.all(movies.map(({ url }) => extractFromMoviePage(url)))
   ).flat()
 
-  logger.info('extractFromMainPage', { screenings })
+  logger.debug('extractFromMainPage', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/forumgroningen.ts
+++ b/cloud/scrapers/forumgroningen.ts
@@ -75,7 +75,7 @@ const extractFromMoviePage = async ({
     ]),
   })
 
-  logger.info('scrapeResult', { scrapeResult })
+  logger.debug('scrapeResult', { scrapeResult })
 
   const screenings: Screening[] = scrapeResult.screenings.flatMap(
     ({ date, times }) => {
@@ -112,7 +112,7 @@ const extractFromMoviePage = async ({
   )
 
   const uniqueSortedScreenings = makeScreeningsUniqueAndSorted(screenings)
-  logger.info('screenings', { screenings: uniqueSortedScreenings })
+  logger.debug('screenings', { screenings: uniqueSortedScreenings })
   return uniqueSortedScreenings
 }
 
@@ -140,13 +140,13 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ...new Map(scrapedMovies.map((obj) => [obj.url, obj])).values(),
   ]
 
-  logger.info('extracted', { movies })
+  logger.debug('extracted', { movies })
 
   const screenings = (
     await Promise.all(movies.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/hartlooper.ts
+++ b/cloud/scrapers/hartlooper.ts
@@ -48,7 +48,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     await got('https://hartlooper.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -69,7 +69,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/heerenstraattheater.ts
+++ b/cloud/scrapers/heerenstraattheater.ts
@@ -74,7 +74,7 @@ const extractFromMoviePage = async ({
     details: ['.detailinfo p | normalizeWhitespace | trim'],
   })
 
-  logger.info('movie page', { url, movie })
+  logger.debug('movie page', { url, movie })
 
   const year = parseReleaseYear(movie.details)
 
@@ -101,7 +101,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { results })
+  logger.debug('main page', { results })
 
   const screenings = (
     await Promise.all(

--- a/cloud/scrapers/hetdocumentairepaviljoen.ts
+++ b/cloud/scrapers/hetdocumentairepaviljoen.ts
@@ -71,7 +71,7 @@ const isTodayOrLater = (show: CinemaFilmDetailShow) => {
 
 const extractFromMoviePage = async (film: MainPageCinemaScheduleFilm) => {
   const { title, url, filmId } = film
-  logger.info('extractFromMoviePage', { title, url, filmId })
+  logger.debug('extractFromMoviePage', { title, url, filmId })
 
   const data = JSON.parse(await xray(url, '#__NEXT_DATA__')) as {
     props: {
@@ -89,7 +89,7 @@ const extractFromMoviePage = async (film: MainPageCinemaScheduleFilm) => {
     return []
   }
 
-  // logger.info('data', { data }) // uncomment to debug structure of __NEXT_DATA__
+  // logger.debug('data', { data }) // uncomment to debug structure of __NEXT_DATA__
 
   const filmDetail = dehydratedState.queries.find(({ queryKey }) =>
     queryKey.includes('CinemaFilmDetail'),
@@ -114,7 +114,7 @@ const extractFromMoviePage = async (film: MainPageCinemaScheduleFilm) => {
       }
     })
 
-  logger.info('moviepage screenings', { url, screenings })
+  logger.debug('moviepage screenings', { url, screenings })
 
   return screenings
 }
@@ -174,14 +174,14 @@ const extractFromMainPage = async () => {
       index === self.findIndex((t) => t.filmId === film.filmId),
   )
 
-  logger.info('mainpage films', { uniqueFilms })
+  logger.debug('mainpage films', { uniqueFilms })
 
   // the __NEXT_DATA__ of the page doesn't contain subtitle information, so we need to filter it out
   const screenings = await (
     await Promise.all(uniqueFilms.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
   return screenings
 }
 

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -434,7 +434,7 @@ export const scrapers = async () => {
       ).length,
     }
 
-    logger.warn('writing to analytics json', { countPerScraper })
+    logger.info('writing to analytics', { countPerScraper })
     await writeToAnalytics('count')(countPerScraper)
   } catch (error) {
     logger.error('error scraping (main loop)', { error })

--- a/cloud/scrapers/index.ts
+++ b/cloud/scrapers/index.ts
@@ -188,13 +188,10 @@ export const scrapers = async () => {
   try {
     const ENABLED_SCRAPERS = getEnabledScrapers()
 
-    logger.info('available scrapers', { SCRAPERS: Object.keys(SCRAPERS) })
-    logger.info('enabled scrapers', {
-      ENABLED_SCRAPERS: Object.keys(ENABLED_SCRAPERS),
-    })
-    logger.info('number of scrapers', {
-      numberOfAvailableScrapers: Object.keys(SCRAPERS).length,
-      numberOfEnabledScrapers: Object.keys(ENABLED_SCRAPERS).length,
+    logger.info('starting scrapers', {
+      availableScrapers: Object.keys(SCRAPERS).length,
+      enabledScrapers: Object.keys(ENABLED_SCRAPERS).length,
+      enabled: Object.keys(ENABLED_SCRAPERS),
     })
 
     const results = Object.fromEntries(
@@ -202,7 +199,7 @@ export const scrapers = async () => {
         Object.entries(ENABLED_SCRAPERS).map(async ([name, fn]) => {
           logger.info('start scraping', { scraper: name })
 
-          // call the scraper function
+          const start = Date.now()
           let result: Screening[] = []
           try {
             result = await fn()
@@ -216,6 +213,7 @@ export const scrapers = async () => {
           logger.info('done scraping', {
             scraper: name,
             numberOfResults: result?.length,
+            durationMs: Date.now() - start,
           })
 
           return [name, makeScreeningsUniqueAndSorted(result)]

--- a/cloud/scrapers/ketelhuis.ts
+++ b/cloud/scrapers/ketelhuis.ts
@@ -82,13 +82,13 @@ const extractFromMainPage = async () => {
       retries: 5,
     },
   )
-  logger.info('scraped /expat-cinema', { expatCinemaResults })
+  logger.debug('scraped /expat-cinema', { expatCinemaResults })
 
   const results = [...expatCinemaResults]
   const uniqueResults = uniq(results)
 
-  logger.info('results', { results })
-  logger.info('uniqueResults', { uniqueResults })
+  logger.debug('results', { results })
+  logger.debug('uniqueResults', { uniqueResults })
 
   const screenings = await (
     await Promise.all(
@@ -163,7 +163,7 @@ const extractFromMoviePage = async ({
   url,
   title,
 }: KetelhuisListing): Promise<Screening[]> => {
-  logger.info('extracting', { url })
+  logger.debug('extracting', { url })
 
   const scrapeResult = (await xray(url, {
     title: '.c-filmheader__content h1 > span', // not using cleanTitle because we want to keep the "English subs" part here
@@ -179,10 +179,10 @@ const extractFromMoviePage = async ({
     ]),
   })) as KetelhuisMoviePage
 
-  logger.info('extracted', { url, scrapeResult })
+  logger.debug('extracted', { url, scrapeResult })
 
   if (!hasEnglishSubtitles(scrapeResult)) {
-    logger.info('hasEnglishSubtitles false', { url })
+    logger.debug('hasEnglishSubtitles false', { url })
 
     return []
   }
@@ -238,7 +238,7 @@ const extractFromMoviePage = async ({
     year: releaseYear,
   }))
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
   return screenings
 }
 

--- a/cloud/scrapers/kinorotterdam.ts
+++ b/cloud/scrapers/kinorotterdam.ts
@@ -76,7 +76,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     await got('https://kinorotterdam.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -95,7 +95,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/kriterion.ts
+++ b/cloud/scrapers/kriterion.ts
@@ -141,7 +141,7 @@ const extractFromMainPage = async () => {
       'https://www.kriterion.nl/data/films.json',
     ).json()
 
-    logger.info('extracted api responses', {
+    logger.debug('extracted api responses', {
       showsApiResponse,
       filmsApiResponse,
     })
@@ -201,7 +201,7 @@ const extractFromMainPage = async () => {
         return true
       })
 
-    logger.info('extracted screenings', { screenings })
+    logger.debug('extracted screenings', { screenings })
     return screenings
   } catch (error) {
     logger.error('error scraping kriterion', { error })

--- a/cloud/scrapers/lab1.ts
+++ b/cloud/scrapers/lab1.ts
@@ -130,7 +130,7 @@ const extractFromMoviePage = async ({
   url: string
   title: string
 }) => {
-  logger.info('movie page', { url })
+  logger.debug('movie page', { url })
 
   // #content so we get the 2nd JSON-LD script tag
   // const scrapeResult: XRayFromMoviePage = await xray(url, '#content', {
@@ -148,7 +148,7 @@ const extractFromMoviePage = async ({
     ]),
   })
 
-  logger.info('scrape result', { scrapeResult })
+  logger.debug('scrape result', { scrapeResult })
 
   const year = extractMetadataYear(scrapeResult.metadata ?? [])
 
@@ -164,13 +164,13 @@ const extractFromMoviePage = async ({
       }
     })
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
   return screenings
 }
 
 const extractFromMainPage = async () => {
   try {
-    logger.info('main page')
+    logger.debug('main page')
 
     const scrapeResult: XRayFromMainPage[] = await xray(
       'https://www.lab-1.nl/expats/',
@@ -183,13 +183,13 @@ const extractFromMainPage = async () => {
       ],
     )
 
-    logger.info('scrape result', { scrapeResult })
+    logger.debug('scrape result', { scrapeResult })
 
     const screenings: Screening[] = (
       await Promise.all(scrapeResult.map(extractFromMoviePage))
     ).flat()
 
-    logger.info('screenings found', { screenings })
+    logger.debug('screenings found', { screenings })
 
     return screenings
   } catch (error) {

--- a/cloud/scrapers/lab111.ts
+++ b/cloud/scrapers/lab111.ts
@@ -80,7 +80,7 @@ const parseReleaseYear = (detailPage: XRayFromDetailPage) => {
 
 const extractFromMainPage = async () => {
   try {
-    logger.info('main page')
+    logger.debug('main page')
 
     const scrapeResult: XRayFromMainPage[] = await xray(
       // 'http://webcache.googleusercontent.com/search?q=cache:https://www.lab111.nl/programma/',
@@ -96,7 +96,7 @@ const extractFromMainPage = async () => {
       ],
     )
 
-    logger.info('scrape result', { scrapeResult })
+    logger.debug('scrape result', { scrapeResult })
 
     const releaseYearByUrl = new Map(
       await Promise.all(
@@ -165,7 +165,7 @@ const extractFromMainPage = async () => {
         })
       })
 
-    logger.info('screenings found', { screenings })
+    logger.debug('screenings found', { screenings })
 
     return screenings
   } catch (error) {

--- a/cloud/scrapers/lantarenvenster.ts
+++ b/cloud/scrapers/lantarenvenster.ts
@@ -46,7 +46,7 @@ type XRayFromMoviePage = {
 export const extractFromMoviePage = async (
   url: string,
 ): Promise<Screening[]> => {
-  logger.info('extracting', { url })
+  logger.debug('extracting', { url })
 
   const movie: XRayFromMoviePage = await xray(url, '.page-content-aside', {
     title: '.wp_theatre_prod_title',
@@ -59,7 +59,7 @@ export const extractFromMoviePage = async (
     ]),
   })
 
-  logger.info('extracted xray', { url, movie })
+  logger.debug('extracted xray', { url, movie })
 
   if (!hasEnglishSubtitles(movie)) return []
 
@@ -98,7 +98,7 @@ export const extractFromMoviePage = async (
     })
     .flat()
 
-  logger.info('extracting done', { url, screenings })
+  logger.debug('extracting done', { url, screenings })
 
   return screenings
 }
@@ -109,7 +109,7 @@ type XRayFromMainPage = {
 }
 
 const extractFromMainPage = async () => {
-  logger.info('extracting main page')
+  logger.debug('extracting main page')
 
   const xrayResult: XRayFromMainPage[] = await xray(
     'https://www.lantarenvenster.nl/#all',
@@ -124,11 +124,11 @@ const extractFromMainPage = async () => {
 
   const uniqueUrls = Array.from(new Set(xrayResult.map((x) => x.url)))
 
-  logger.info('main page', { uniqueUrls })
+  logger.debug('main page', { uniqueUrls })
 
   const screenings = await Promise.all(uniqueUrls.map(extractFromMoviePage))
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/liff.ts
+++ b/cloud/scrapers/liff.ts
@@ -49,7 +49,7 @@ const extractFromMoviePage = ({
 }: LiffListing): Promise<
   { title: string; url: string; date: string; cinema: string }[]
 > => {
-  logger.info('extracting', { url })
+  logger.debug('extracting', { url })
 
   return xray(url, 'body', {
     title: '.film-title span | trim',

--- a/cloud/scrapers/lumiere.ts
+++ b/cloud/scrapers/lumiere.ts
@@ -63,7 +63,7 @@ type XRayFromMoviePage = {
 }
 
 const extractFromMoviePage = async (url: string): Promise<Screening[]> => {
-  logger.info('extracting', { url })
+  logger.debug('extracting', { url })
 
   const movie: XRayFromMoviePage = await xray(url, {
     title: '.movie-intro h1 | cleanTitle | trim',
@@ -76,7 +76,7 @@ const extractFromMoviePage = async (url: string): Promise<Screening[]> => {
     ]),
   })
 
-  logger.info('extractFromMoviePage', { movie })
+  logger.debug('extractFromMoviePage', { movie })
 
   if (!movie?.metadata?.includes('engels ondertiteld')) {
     logger.warn('extractFromMoviePage without english subtitles', {
@@ -135,13 +135,13 @@ const extractFromProgrammaPage = async () => {
     },
   ])
 
-  logger.info('extractFromProgrammaPage', { movies })
+  logger.debug('extractFromProgrammaPage', { movies })
 
   const filteredMovies = movies.filter(({ title, metadata }) => {
     return metadata?.includes('engels ondertiteld')
   })
 
-  logger.info('extractFromProgrammaPage', { filteredMovies })
+  logger.debug('extractFromProgrammaPage', { filteredMovies })
   return filteredMovies
 }
 
@@ -159,7 +159,7 @@ const extractFromEnglishSubtitledPage = async () => {
     ],
   )
 
-  logger.info('extractFromEnglishSubtitledPage', { movies })
+  logger.debug('extractFromEnglishSubtitledPage', { movies })
 
   return movies
 }
@@ -179,7 +179,7 @@ const extractFromMainPage = async () => {
 
   const screenings = (await Promise.all(urls.map(extractFromMoviePage))).flat()
 
-  logger.info('extractFromMainPage', { screenings })
+  logger.debug('extractFromMainPage', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/lux.ts
+++ b/cloud/scrapers/lux.ts
@@ -117,7 +117,7 @@ const extractFromMoviePage = async ({
     })
   })
 
-  logger.info('extracted screenings', { screenings })
+  logger.debug('extracted screenings', { screenings })
   return screenings
 }
 
@@ -141,13 +141,13 @@ const extractFromMainPage = async () => {
     },
   ).json()
 
-  logger.info('main page', { response })
+  logger.debug('main page', { response })
 
   const screenings = (
     await Promise.all(response.items.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('main page', { screenings })
+  logger.debug('main page', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/melkweg.ts
+++ b/cloud/scrapers/melkweg.ts
@@ -105,14 +105,14 @@ const extractFromMainPage = async () => {
       }
     })
 
-  logger.info('unfilteredScreenings', { unfilteredScreenings })
+  logger.debug('unfilteredScreenings', { unfilteredScreenings })
 
   // the __NEXT_DATA__ of the page doesn't contain subtitle information, so we need to filter it out
   const screenings = (
     await Promise.all(unfilteredScreenings.map(extractFromMoviePage))
   ).filter((x): x is Screening => x !== null)
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
   return screenings
 }
 

--- a/cloud/scrapers/natlab.ts
+++ b/cloud/scrapers/natlab.ts
@@ -71,7 +71,7 @@ const extractFromMoviePage = async ({
     genres: ['.meta .genres li | normalizeWhitespace | trim'],
   })) as NatlabMoviePage
 
-  logger.info('movie page', { scrapeResult })
+  logger.debug('movie page', { scrapeResult })
 
   // example
   // {"title":"The Zone of Interest | Expat Cinema","screenings":[{"date":"zo 14 apr","times":["14:30"]}]}}
@@ -81,7 +81,7 @@ const extractFromMoviePage = async ({
       scrapeResult.metadata.value[index],
     ]),
   )
-  logger.info('metadata', { metadata })
+  logger.debug('metadata', { metadata })
 
   if (
     !(
@@ -90,11 +90,11 @@ const extractFromMoviePage = async ({
       scrapeResult.title.includes('[Eng Subs]')
     )
   ) {
-    logger.info('no English subtitles', { url, title })
+    logger.debug('no English subtitles', { url, title })
     return []
   }
 
-  logger.info('screenings', { screenings: scrapeResult.screenings })
+  logger.debug('screenings', { screenings: scrapeResult.screenings })
 
   const screenings: Screening[] = scrapeResult.screenings.flatMap(
     (screening: NatlabMoviePage['screenings'][number]) => {
@@ -130,7 +130,7 @@ const extractFromMoviePage = async ({
     },
   )
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
   return screenings
 }
 
@@ -149,13 +149,13 @@ const extractFromMainPage = async () => {
     ],
   )
 
-  logger.info('main page', { scrapeResult })
+  logger.debug('main page', { scrapeResult })
 
   const screenings = (
     await Promise.all(scrapeResult.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/rialto.ts
+++ b/cloud/scrapers/rialto.ts
@@ -117,7 +117,7 @@ const extractFromMainPage = async () => {
     await Promise.all(movies.map(extractFromMoviePage))
   ).flat()
 
-  logger.info('main page', { screenings })
+  logger.debug('main page', { screenings })
 
   return screenings
 }

--- a/cloud/scrapers/schuur.ts
+++ b/cloud/scrapers/schuur.ts
@@ -45,7 +45,7 @@ type XRayFromMainPage = {
 
 const extractFromMainPage = async () => {
   try {
-    logger.info('main page')
+    logger.debug('main page')
 
     const scrapeResult: XRayFromMainPage[] = await xray(
       'https://www.schuur.nl/expat-cinema',
@@ -60,7 +60,7 @@ const extractFromMainPage = async () => {
       ],
     )
 
-    logger.info('scrape result', { scrapeResult })
+    logger.debug('scrape result', { scrapeResult })
 
     const screenings: Screening[] = scrapeResult.map(
       ({ title, url, date, time }) => {
@@ -91,7 +91,7 @@ const extractFromMainPage = async () => {
       },
     )
 
-    logger.info('screenings found', { screenings })
+    logger.debug('screenings found', { screenings })
 
     return screenings
   } catch (error) {

--- a/cloud/scrapers/slachtstraat.ts
+++ b/cloud/scrapers/slachtstraat.ts
@@ -45,7 +45,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     await got('https://slachtstraat.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -63,7 +63,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/sliekerfilm.ts
+++ b/cloud/scrapers/sliekerfilm.ts
@@ -111,7 +111,7 @@ const extractFromMoviePage = async ({
     }) as unknown as Promise<MovieDetailPage>,
   ])
 
-  logger.info('movie page', { id, link, movie, detailPage })
+  logger.debug('movie page', { id, link, movie, detailPage })
 
   if (movie.status !== 'available' || !hasEnglishSubtitles(detailPage)) {
     return []
@@ -133,7 +133,7 @@ const extractFromMoviePage = async ({
     }))
     .filter(({ date }) => date >= DateTime.now().minus({ hours: 1 }).toJSDate())
 
-  logger.info('screenings found for movie', { id, link, screenings })
+  logger.debug('screenings found for movie', { id, link, screenings })
 
   return screenings
 }
@@ -141,7 +141,7 @@ const extractFromMoviePage = async ({
 const extractFromMainPage = async (): Promise<Screening[]> => {
   const movies = await got(CURRENT_MOVIES_URL).json<ProductionSummary[]>()
 
-  logger.info('main page', { count: movies.length, movies })
+  logger.debug('main page', { count: movies.length, movies })
 
   const screenings = (
     await Promise.all(
@@ -151,7 +151,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     )
   ).flat()
 
-  logger.info('screenings found', { count: screenings.length, screenings })
+  logger.debug('screenings found', { count: screenings.length, screenings })
 
   return makeScreeningsUniqueAndSorted(screenings)
 }

--- a/cloud/scrapers/springhaver.ts
+++ b/cloud/scrapers/springhaver.ts
@@ -38,7 +38,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     await got('https://springhaver.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -58,7 +58,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/studiok.ts
+++ b/cloud/scrapers/studiok.ts
@@ -68,7 +68,7 @@ const extractFromMoviePage = async (url: string) => {
     ]),
   })
 
-  logger.info('movie', { movie })
+  logger.debug('movie', { movie })
 
   const screenings: Screening[] = movie.timetable
     .flatMap(({ date, times, subtitles }) => {
@@ -117,7 +117,7 @@ const extractFromMoviePage = async (url: string) => {
     })
     .flat()
 
-  logger.info('screenings', { screenings })
+  logger.debug('screenings', { screenings })
   return screenings
 }
 
@@ -138,11 +138,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
     ],
   )
 
-  logger.info('main page', { scrapeResult })
+  logger.debug('main page', { scrapeResult })
 
   const uniqueUrls = Array.from(new Set(scrapeResult.map((x) => x.url)))
 
-  logger.info('uniqueUrls', { uniqueUrls, length: uniqueUrls.length })
+  logger.debug('uniqueUrls', { uniqueUrls, length: uniqueUrls.length })
 
   const screenings = await (
     await Promise.all(

--- a/cloud/scrapers/themovies.ts
+++ b/cloud/scrapers/themovies.ts
@@ -51,7 +51,7 @@ const extractFromMainPage = async () => {
     await got('https://themovies.nl/fk-feed/agenda').json(),
   )
 
-  logger.info('main page', { movies })
+  logger.debug('main page', { movies })
 
   const screenings: Screening[][] = movies
     .map((movie) => {
@@ -69,7 +69,7 @@ const extractFromMainPage = async () => {
     })
     .filter((x) => x)
 
-  logger.info('before flatten', { screenings })
+  logger.debug('before flatten', { screenings })
 
   return screenings.flat()
 }

--- a/cloud/scrapers/worm.ts
+++ b/cloud/scrapers/worm.ts
@@ -90,7 +90,7 @@ const getProductionResults = async (): Promise<SearchResult[]> => {
       url.startsWith(`${BASE_URL}/production/`),
   )
 
-  logger.info('search results', {
+  logger.debug('search results', {
     searchTerm: SEARCH_TERM,
     count: productions.length,
     productions,
@@ -152,7 +152,7 @@ const extractFromProductionPage = async ({
     ]),
   })
 
-  logger.info('production page', { title, url, page })
+  logger.debug('production page', { title, url, page })
 
   if (!hasEnglishSubtitles(page.detailParagraphs)) {
     return []
@@ -161,7 +161,7 @@ const extractFromProductionPage = async ({
   const titleAndYear = parseTitleAndYear(page)
 
   if (!titleAndYear) {
-    logger.info('skipping ambiguous multi-film production', {
+    logger.debug('skipping ambiguous multi-film production', {
       title,
       url,
       page,

--- a/cloud/xRayPuppeteer.ts
+++ b/cloud/xRayPuppeteer.ts
@@ -20,7 +20,7 @@ const xRayPuppeteer = ({
     try {
       const browser = await getBrowser({ logger })
 
-      logger?.info('opening page', { url: ctx.url })
+      logger?.debug('opening page', { url: ctx.url })
       let page = await browser.newPage()
       await page.goto(String(ctx.url), waitForOptions)
 
@@ -31,11 +31,11 @@ const xRayPuppeteer = ({
       if (!ctx.body) {
         ctx.body = await page.content()
       }
-      logger?.info('done retrieving content', { url: ctx.url })
+      logger?.debug('done retrieving content', { url: ctx.url })
 
-      logger?.info('closing page', { url: ctx.url })
+      logger?.debug('closing page', { url: ctx.url })
       await page.close()
-      logger?.info('closed page', { url: ctx.url })
+      logger?.debug('closed page', { url: ctx.url })
 
       done(null, ctx)
     } catch (error) {


### PR DESCRIPTION
## Summary

- Downgraded all intermediate scraping data (page contents, per-URL extraction steps, TMDB candidate scoring, browser lifecycle) from `logger.info` to `logger.debug` across 38 scraper files, `browser.ts`, `xRayPuppeteer.ts`, and `metadata/searchMetadata.ts` — CloudWatch and Slack now only surface genuine operational signals
- Fixed `logger.warn` → `logger.info` for the analytics write in `scrapers/index.ts`, which was firing a spurious Slack alert on every successful run
- Removed commented-out `console.log` in `lib/config.ts`

## Test plan

- [ ] Verify the scrapers Lambda runs without errors
- [ ] Confirm no WARN-level Slack notification fires after a clean run
- [ ] Confirm ERROR/WARN Slack notifications still fire when a scraper fails