### PR TITLE
Fix focusarnhem subtitle detection for Dutch 'Engels' spelling

### DIFF
--- a/cloud/scrapers/focusarnhem.ts
+++ b/cloud/scrapers/focusarnhem.ts
@@ -68,7 +68,7 @@ type XRayFromMainPage = {
 }
 
 const hasEnglishSubtitles = (movie: XRayFromMoviePage) => {
-  return /ondertiteling: english/i.test(movie.metadata)
+  return /ondertiteling: (english|engels)/i.test(movie.metadata)
 }
 
 const splitDate = (date: string) => {


### PR DESCRIPTION
## Summary

- The focusarnhem scraper checks for `ondertiteling: english` in movie metadata to determine if a film has English subtitles
- The website now uses the Dutch spelling `ondertiteling: Engels` instead, causing movies with English subtitles (e.g. Hysteria) to be silently dropped
- Extended the regex to match both `english` and `engels` (case-insensitive)

## What changed

`cloud/scrapers/focusarnhem.ts` — one-line regex fix in `hasEnglishSubtitles`.

## How it was found

The Slack #expatcinema channel showed repeated `extractFromMoviePage without english subtitles` warnings for Hysteria. Fetching the movie page confirmed it has `ondertiteling: Engels` — the Dutch word — while the regex only matched the English word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)