### PR TITLE
Add logger.warn when scraper movie pages lack English subtitles

### DIFF
--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -91,7 +91,13 @@ export const extractFromMoviePage = async (
 
   logger.debug('extracted xray', { url, movie })
 
-  if (!hasEnglishSubtitles(movie)) return []
+  if (!hasEnglishSubtitles(movie)) {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url,
+      title: movie.title,
+    })
+    return []
+  }
 
   const screenings: Screening[] = movie.screenings.map((screening) => {
     return {

--- a/cloud/scrapers/fchyena.ts
+++ b/cloud/scrapers/fchyena.ts
@@ -124,6 +124,10 @@ const extractFromMoviePage = async (
   logger.debug('detail page', { movie, detailPage })
 
   if (!hasEnglishSubtitles(detailPage)) {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url: movie.url,
+      title: movie.title,
+    })
     return []
   }
 

--- a/cloud/scrapers/filmhuislumen.ts
+++ b/cloud/scrapers/filmhuislumen.ts
@@ -109,6 +109,10 @@ const extractFromMoviePage = async ({
   logger.debug('extractFromMoviePage', { movie })
 
   if (!hasEnglishSubtitles(movie)) {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url,
+      title,
+    })
     return []
   }
 

--- a/cloud/scrapers/filmtheaterhilversum.ts
+++ b/cloud/scrapers/filmtheaterhilversum.ts
@@ -147,6 +147,10 @@ const extractFromMoviePage = async ({
   logger.debug('movie page', { title, url, detailPage })
 
   if (!hasEnglishSubtitles(detailPage)) {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url,
+      title,
+    })
     return []
   }
 

--- a/cloud/scrapers/ketelhuis.ts
+++ b/cloud/scrapers/ketelhuis.ts
@@ -182,7 +182,7 @@ const extractFromMoviePage = async ({
   logger.debug('extracted', { url, scrapeResult })
 
   if (!hasEnglishSubtitles(scrapeResult)) {
-    logger.debug('hasEnglishSubtitles false', { url })
+    logger.warn('extractFromMoviePage without english subtitles', { url })
 
     return []
   }

--- a/cloud/scrapers/lantarenvenster.ts
+++ b/cloud/scrapers/lantarenvenster.ts
@@ -61,7 +61,13 @@ export const extractFromMoviePage = async (
 
   logger.debug('extracted xray', { url, movie })
 
-  if (!hasEnglishSubtitles(movie)) return []
+  if (!hasEnglishSubtitles(movie)) {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url,
+      title: movie.title,
+    })
+    return []
+  }
 
   const screenings: Screening[] = movie.screenings
     .map(({ date, times }) => {

--- a/cloud/scrapers/melkweg.ts
+++ b/cloud/scrapers/melkweg.ts
@@ -78,6 +78,10 @@ const extractFromMoviePage = async (screening: Screening) => {
   if (hasEnglishSubtitles) {
     return screening
   } else {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url: screening.url,
+      title: screening.title,
+    })
     return null
   }
 }

--- a/cloud/scrapers/natlab.ts
+++ b/cloud/scrapers/natlab.ts
@@ -90,7 +90,7 @@ const extractFromMoviePage = async ({
       scrapeResult.title.includes('[Eng Subs]')
     )
   ) {
-    logger.debug('no English subtitles', { url, title })
+    logger.warn('extractFromMoviePage without english subtitles', { url, title })
     return []
   }
 

--- a/cloud/scrapers/sliekerfilm.ts
+++ b/cloud/scrapers/sliekerfilm.ts
@@ -113,7 +113,15 @@ const extractFromMoviePage = async ({
 
   logger.debug('movie page', { id, link, movie, detailPage })
 
-  if (movie.status !== 'available' || !hasEnglishSubtitles(detailPage)) {
+  if (movie.status !== 'available') {
+    return []
+  }
+
+  if (!hasEnglishSubtitles(detailPage)) {
+    logger.warn('extractFromMoviePage without english subtitles', {
+      url: link,
+      title,
+    })
     return []
   }
 


### PR DESCRIPTION
## Summary

- Nine scrapers follow a two-step pattern (main listing page → individual movie page) but silently dropped movies when the subtitle check on the movie page failed
- Added a consistent `logger.warn('extractFromMoviePage without english subtitles', { url, title })` so these cases show up in the #expatcinema Slack channel, matching the pattern already in `focusarnhem` and `lumiere`

## Scrapers changed

| Scraper | Change |
|---|---|
| `deuitkijk` | Add missing `logger.warn` before `return []` |
| `fchyena` | Add missing `logger.warn` before `return []` |
| `filmhuislumen` | Add missing `logger.warn` before `return []` |
| `filmtheaterhilversum` | Add missing `logger.warn` before `return []` |
| `lantarenvenster` | Add missing `logger.warn` before `return []` |
| `melkweg` | Add missing `logger.warn` before `return null` |
| `sliekerfilm` | Add missing `logger.warn` before `return []`; also split `movie.status` check from subtitle check so the warn only fires for the subtitle case |
| `ketelhuis` | Upgrade `logger.debug` → `logger.warn`, standardise message |
| `natlab` | Upgrade `logger.debug` → `logger.warn`, standardise message |

## Context

Spotted while investigating the focusarnhem `Hysteria` warning (PR #357) — the fix there made it clear that several other scrapers had the same pattern but lacked visibility when the subtitle check failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)