### PR TITLE
Make per-film-page scraping resilient to single-page failures

### DIFF
--- a/cloud/scrapers/cinemadevlugt.ts
+++ b/cloud/scrapers/cinemadevlugt.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { createXray } from '../xRay'
@@ -96,9 +97,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
   logger.debug('main page', { movies })
 
-  const screenings = (
-    await Promise.all(movies.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    movies,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('screenings found', { count: screenings.length, screenings })
 

--- a/cloud/scrapers/cinemadevlugt.ts
+++ b/cloud/scrapers/cinemadevlugt.ts
@@ -100,7 +100,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const screenings = await extractScreeningsFromPages(
     movies,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('screenings found', { count: screenings.length, screenings })

--- a/cloud/scrapers/deuitkijk.ts
+++ b/cloud/scrapers/deuitkijk.ts
@@ -6,6 +6,7 @@ import { type Driver } from 'x-ray-crawler'
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { extractYearFromTitle } from './utils/extractYearFromTitle'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { USER_AGENT } from '../xRay'
@@ -135,11 +136,13 @@ const extractFromMainPage = async () => {
 
   logger.debug('main page', { uniqueUrls })
 
-  const screenings = await Promise.all(uniqueUrls.map(extractFromMoviePage))
+  const screenings = await extractScreeningsFromPages(
+    uniqueUrls,
+    extractFromMoviePage,
+    { logger },
+  )
 
-  logger.debug('before flatten', { screenings })
-
-  return screenings.flat()
+  return screenings
 }
 
 runIfMain(extractFromMainPage, import.meta.url)

--- a/cloud/scrapers/dewittdordrecht.ts
+++ b/cloud/scrapers/dewittdordrecht.ts
@@ -5,6 +5,7 @@ import { Screening } from '../types'
 import { guessYear } from './utils/guessYear'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -104,9 +105,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
       url: new URL(url, BASE_URL).toString(),
     }))
 
-  const screenings = (
-    await Promise.all(expatCinemaPages.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    expatCinemaPages,
+    extractFromMoviePage,
+    { logger },
+  )
 
   return makeScreeningsUniqueAndSorted(screenings)
 }

--- a/cloud/scrapers/dewittdordrecht.ts
+++ b/cloud/scrapers/dewittdordrecht.ts
@@ -108,7 +108,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const screenings = await extractScreeningsFromPages(
     expatCinemaPages,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   return makeScreeningsUniqueAndSorted(screenings)

--- a/cloud/scrapers/dokhuis.ts
+++ b/cloud/scrapers/dokhuis.ts
@@ -104,7 +104,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const screenings = await extractScreeningsFromPages(
     movies,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('screenings', { screenings })

--- a/cloud/scrapers/dokhuis.ts
+++ b/cloud/scrapers/dokhuis.ts
@@ -4,6 +4,7 @@ import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { guessYear } from './utils/guessYear'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { useLLM } from './utils/useLLM'
@@ -100,9 +101,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
   logger.debug('extracted', { movies })
 
-  const screenings = (
-    await Promise.all(movies.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    movies,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('screenings', { screenings })
 

--- a/cloud/scrapers/fchyena.ts
+++ b/cloud/scrapers/fchyena.ts
@@ -150,7 +150,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
         url: new URL(url, BASE_URL).toString(),
         productionId,
       }),
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   return makeScreeningsUniqueAndSorted(screenings)

--- a/cloud/scrapers/fchyena.ts
+++ b/cloud/scrapers/fchyena.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon'
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { createXray } from '../xRay'
 
@@ -141,17 +142,16 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
   logger.debug('main page', { results })
 
-  const screenings = (
-    await Promise.all(
-      results.map(({ title, url, productionId }) =>
-        extractFromMoviePage({
-          title,
-          url: new URL(url, BASE_URL).toString(),
-          productionId,
-        }),
-      ),
-    )
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    results,
+    ({ title, url, productionId }) =>
+      extractFromMoviePage({
+        title,
+        url: new URL(url, BASE_URL).toString(),
+        productionId,
+      }),
+    { logger },
+  )
 
   return makeScreeningsUniqueAndSorted(screenings)
 }

--- a/cloud/scrapers/filmhuislumen.ts
+++ b/cloud/scrapers/filmhuislumen.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
 import { fullMonthToNumberDutch } from './utils/monthToNumber'
 import { runIfMain } from './utils/runIfMain'
@@ -174,9 +175,11 @@ const extractFromMainPage = async () => {
 
   logger.debug('scrape result', { scrapeResult })
 
-  const screenings: Screening[] = (
-    await Promise.all(scrapeResult.map(extractFromMoviePage))
-  ).flat()
+  const screenings: Screening[] = await extractScreeningsFromPages(
+    scrapeResult,
+    extractFromMoviePage,
+    { logger, describe: ({ url }) => url },
+  )
 
   logger.debug('screenings found', { screenings })
 

--- a/cloud/scrapers/filmhuislumen.ts
+++ b/cloud/scrapers/filmhuislumen.ts
@@ -178,7 +178,7 @@ const extractFromMainPage = async () => {
   const screenings: Screening[] = await extractScreeningsFromPages(
     scrapeResult,
     extractFromMoviePage,
-    { logger, describe: ({ url }) => url },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('screenings found', { screenings })

--- a/cloud/scrapers/focusarnhem.ts
+++ b/cloud/scrapers/focusarnhem.ts
@@ -6,6 +6,7 @@ import { Screening } from '../types'
 import xRayPuppeteer from '../xRayPuppeteer'
 import { guessYear } from './utils/guessYear'
 import { monthToNumber } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -159,9 +160,11 @@ const extractFromMainPage = async () => {
 
   logger.debug('movies', { movies })
 
-  const screenings = (
-    await Promise.all(movies.map(({ url }) => extractFromMoviePage(url)))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    movies,
+    ({ url }) => extractFromMoviePage(url),
+    { logger },
+  )
 
   logger.debug('extractFromMainPage', { screenings })
 

--- a/cloud/scrapers/focusarnhem.ts
+++ b/cloud/scrapers/focusarnhem.ts
@@ -163,7 +163,7 @@ const extractFromMainPage = async () => {
   const screenings = await extractScreeningsFromPages(
     movies,
     ({ url }) => extractFromMoviePage(url),
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('extractFromMainPage', { screenings })

--- a/cloud/scrapers/forumgroningen.ts
+++ b/cloud/scrapers/forumgroningen.ts
@@ -5,6 +5,7 @@ import { Screening } from '../types'
 import { guessYear } from './utils/guessYear'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
 import { fullMonthToNumberEnglish } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { createXray } from '../xRay'
@@ -137,9 +138,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
   logger.debug('extracted', { movies })
 
-  const screenings = (
-    await Promise.all(movies.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    movies,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('screenings', { screenings })
 

--- a/cloud/scrapers/forumgroningen.ts
+++ b/cloud/scrapers/forumgroningen.ts
@@ -141,7 +141,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const screenings = await extractScreeningsFromPages(
     movies,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('screenings', { screenings })

--- a/cloud/scrapers/heerenstraattheater.ts
+++ b/cloud/scrapers/heerenstraattheater.ts
@@ -3,6 +3,7 @@ import { DateTime } from 'luxon'
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { createXray } from '../xRay'
@@ -94,16 +95,15 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
 
   logger.debug('main page', { results })
 
-  const screenings = (
-    await Promise.all(
-      results.map(({ title, url }) =>
-        extractFromMoviePage({
-          title,
-          url: new URL(url, BASE_URL).toString(),
-        }),
-      ),
-    )
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    results,
+    ({ title, url }) =>
+      extractFromMoviePage({
+        title,
+        url: new URL(url, BASE_URL).toString(),
+      }),
+    { logger },
+  )
 
   return makeScreeningsUniqueAndSorted(screenings)
 }

--- a/cloud/scrapers/heerenstraattheater.ts
+++ b/cloud/scrapers/heerenstraattheater.ts
@@ -102,7 +102,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
         title,
         url: new URL(url, BASE_URL).toString(),
       }),
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   return makeScreeningsUniqueAndSorted(screenings)

--- a/cloud/scrapers/hetdocumentairepaviljoen.ts
+++ b/cloud/scrapers/hetdocumentairepaviljoen.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { createXray } from '../xRay'
@@ -177,9 +178,11 @@ const extractFromMainPage = async () => {
   logger.debug('mainpage films', { uniqueFilms })
 
   // the __NEXT_DATA__ of the page doesn't contain subtitle information, so we need to filter it out
-  const screenings = await (
-    await Promise.all(uniqueFilms.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    uniqueFilms,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('screenings', { screenings })
   return screenings

--- a/cloud/scrapers/hetdocumentairepaviljoen.ts
+++ b/cloud/scrapers/hetdocumentairepaviljoen.ts
@@ -181,7 +181,7 @@ const extractFromMainPage = async () => {
   const screenings = await extractScreeningsFromPages(
     uniqueFilms,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('screenings', { screenings })

--- a/cloud/scrapers/lantarenvenster.ts
+++ b/cloud/scrapers/lantarenvenster.ts
@@ -6,6 +6,7 @@ import { extractYearFromTitle } from './utils/extractYearFromTitle'
 import { guessYear } from './utils/guessYear'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
 import { removeYearSuffix } from './utils/removeYearSuffix'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -119,11 +120,13 @@ const extractFromMainPage = async () => {
 
   logger.debug('main page', { uniqueUrls })
 
-  const screenings = await Promise.all(uniqueUrls.map(extractFromMoviePage))
+  const screenings = await extractScreeningsFromPages(
+    uniqueUrls,
+    extractFromMoviePage,
+    { logger },
+  )
 
-  logger.debug('before flatten', { screenings })
-
-  return screenings.flat()
+  return screenings
 }
 
 runIfMain(extractFromMainPage, import.meta.url)

--- a/cloud/scrapers/lumiere.ts
+++ b/cloud/scrapers/lumiere.ts
@@ -6,6 +6,7 @@ import { Screening } from '../types'
 import xRayPuppeteer from '../xRayPuppeteer'
 import { guessYear } from './utils/guessYear'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -177,7 +178,11 @@ const extractFromMainPage = async () => {
     ),
   ]
 
-  const screenings = (await Promise.all(urls.map(extractFromMoviePage))).flat()
+  const screenings = await extractScreeningsFromPages(
+    urls,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('extractFromMainPage', { screenings })
 

--- a/cloud/scrapers/lux.ts
+++ b/cloud/scrapers/lux.ts
@@ -140,7 +140,7 @@ const extractFromMainPage = async () => {
   const screenings = await extractScreeningsFromPages(
     response.items,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ permalink }) => permalink },
   )
 
   logger.debug('main page', { screenings })

--- a/cloud/scrapers/lux.ts
+++ b/cloud/scrapers/lux.ts
@@ -5,6 +5,7 @@ import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { guessYear } from './utils/guessYear'
 import { fullMonthToNumberEnglish } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -136,9 +137,11 @@ const extractFromMainPage = async () => {
 
   logger.debug('main page', { response })
 
-  const screenings = (
-    await Promise.all(response.items.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    response.items,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('main page', { screenings })
 

--- a/cloud/scrapers/natlab.ts
+++ b/cloud/scrapers/natlab.ts
@@ -4,6 +4,7 @@ import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { guessYear } from './utils/guessYear'
 import { shortMonthToNumberDutch } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -142,9 +143,11 @@ const extractFromMainPage = async () => {
 
   logger.debug('main page', { scrapeResult })
 
-  const screenings = (
-    await Promise.all(scrapeResult.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    scrapeResult,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('screenings', { screenings })
 

--- a/cloud/scrapers/natlab.ts
+++ b/cloud/scrapers/natlab.ts
@@ -146,7 +146,7 @@ const extractFromMainPage = async () => {
   const screenings = await extractScreeningsFromPages(
     scrapeResult,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('screenings', { screenings })

--- a/cloud/scrapers/rialto.ts
+++ b/cloud/scrapers/rialto.ts
@@ -5,6 +5,7 @@ import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { guessYear } from './utils/guessYear'
 import { fullMonthToNumberEnglish } from './utils/monthToNumber'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { splitTime } from './utils/splitTime'
 import { titleCase } from './utils/titleCase'
@@ -110,9 +111,11 @@ const extractFromMainPage = async () => {
     },
   ])
 
-  const screenings = (
-    await Promise.all(movies.map(extractFromMoviePage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    movies,
+    extractFromMoviePage,
+    { logger },
+  )
 
   logger.debug('main page', { screenings })
 

--- a/cloud/scrapers/rialto.ts
+++ b/cloud/scrapers/rialto.ts
@@ -114,7 +114,7 @@ const extractFromMainPage = async () => {
   const screenings = await extractScreeningsFromPages(
     movies,
     extractFromMoviePage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   logger.debug('main page', { screenings })

--- a/cloud/scrapers/utils/extractScreeningsFromPages.ts
+++ b/cloud/scrapers/utils/extractScreeningsFromPages.ts
@@ -6,9 +6,9 @@ type ExtractFromPage<Item> = (item: Item) => Promise<Screening[]>
 
 type Options<Item> = {
   logger: Logger
-  // Describe an item in the warning log when its page fails. Defaults to the
-  // item itself (objects like `{ title, url }` log fine; URLs log as-is).
-  describe?: (item: Item) => unknown
+  // Extract the page URL from an item for the failure log. Defaults to the
+  // item itself, which is correct when items are already URL strings.
+  url?: (item: Item) => unknown
 }
 
 /**
@@ -25,7 +25,7 @@ type Options<Item> = {
 export const extractScreeningsFromPages = async <Item>(
   items: Item[],
   extract: ExtractFromPage<Item>,
-  { logger, describe = (item) => item }: Options<Item>,
+  { logger, url = (item) => item }: Options<Item>,
 ): Promise<Screening[]> => {
   const results = await Promise.allSettled(
     // pRetry seam: wrap this call to retry an individual film page.
@@ -38,7 +38,7 @@ export const extractScreeningsFromPages = async <Item>(
     }
 
     logger.warn('failed to extract screenings from page', {
-      item: describe(items[index]),
+      url: url(items[index]),
       error: result.reason,
     })
 

--- a/cloud/scrapers/utils/extractScreeningsFromPages.ts
+++ b/cloud/scrapers/utils/extractScreeningsFromPages.ts
@@ -1,0 +1,47 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+
+import { Screening } from '../../types'
+
+type ExtractFromPage<Item> = (item: Item) => Promise<Screening[]>
+
+type Options<Item> = {
+  logger: Logger
+  // Describe an item in the warning log when its page fails. Defaults to the
+  // item itself (objects like `{ title, url }` log fine; URLs log as-is).
+  describe?: (item: Item) => unknown
+}
+
+/**
+ * Runs `extract` over every `item` concurrently and returns the flattened
+ * screenings.
+ *
+ * Unlike a bare `Promise.all`, a single failing page does not reject the whole
+ * batch: rejected pages are logged as a warning and contribute no screenings,
+ * so one flaky film page can't zero out an entire cinema.
+ *
+ * `extract` is invoked once per item on the marked line below — that is the
+ * seam for adding a per-film-page `pRetry` later without touching call sites.
+ */
+export const extractScreeningsFromPages = async <Item>(
+  items: Item[],
+  extract: ExtractFromPage<Item>,
+  { logger, describe = (item) => item }: Options<Item>,
+): Promise<Screening[]> => {
+  const results = await Promise.allSettled(
+    // pRetry seam: wrap this call to retry an individual film page.
+    items.map((item) => extract(item)),
+  )
+
+  return results.flatMap((result, index) => {
+    if (result.status === 'fulfilled') {
+      return result.value
+    }
+
+    logger.warn('failed to extract screenings from page', {
+      item: describe(items[index]),
+      error: result.reason,
+    })
+
+    return []
+  })
+}

--- a/cloud/scrapers/worm.ts
+++ b/cloud/scrapers/worm.ts
@@ -5,6 +5,7 @@ import { DateTime } from 'luxon'
 import { logger as parentLogger } from '../powertools'
 import { Screening } from '../types'
 import { makeScreeningsUniqueAndSorted } from './utils/makeScreeningsUniqueAndSorted'
+import { extractScreeningsFromPages } from './utils/extractScreeningsFromPages'
 import { runIfMain } from './utils/runIfMain'
 import { titleCase } from './utils/titleCase'
 import { createXray } from '../xRay'
@@ -175,9 +176,11 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const productions = await getProductionResults()
 
   const now = DateTime.now().minus({ hours: 1 }).toJSDate()
-  const screenings = (
-    await Promise.all(productions.map(extractFromProductionPage))
-  ).flat()
+  const screenings = await extractScreeningsFromPages(
+    productions,
+    extractFromProductionPage,
+    { logger },
+  )
 
   return makeScreeningsUniqueAndSorted(
     screenings.filter(({ date }) => date >= now),

--- a/cloud/scrapers/worm.ts
+++ b/cloud/scrapers/worm.ts
@@ -179,7 +179,7 @@ const extractFromMainPage = async (): Promise<Screening[]> => {
   const screenings = await extractScreeningsFromPages(
     productions,
     extractFromProductionPage,
-    { logger },
+    { logger, url: ({ url }) => url },
   )
 
   return makeScreeningsUniqueAndSorted(

--- a/cloud/test/extractScreeningsFromPages.test.ts
+++ b/cloud/test/extractScreeningsFromPages.test.ts
@@ -1,0 +1,80 @@
+import { Logger } from '@aws-lambda-powertools/logger'
+
+import { Screening } from '../types'
+import { extractScreeningsFromPages } from '../scrapers/utils/extractScreeningsFromPages'
+
+const screening = (title: string): Screening => ({
+  title,
+  url: `https://example.com/${title}`,
+  cinema: 'Test',
+  date: new Date('2026-01-01T20:00:00Z'),
+})
+
+const makeLogger = () =>
+  ({ warn: jest.fn() } as unknown as Logger & { warn: jest.Mock })
+
+describe('extractScreeningsFromPages', () => {
+  test('flattens the screenings from every page', async () => {
+    const logger = makeLogger()
+
+    const result = await extractScreeningsFromPages(
+      ['a', 'b'],
+      async (item) => [screening(item)],
+      { logger },
+    )
+
+    expect(result.map((s) => s.title)).toEqual(['a', 'b'])
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  test('a single failing page does not zero out the rest', async () => {
+    const logger = makeLogger()
+
+    const result = await extractScreeningsFromPages(
+      ['ok-1', 'boom', 'ok-2'],
+      async (item) => {
+        if (item === 'boom') throw new Error('network blip')
+        return [screening(item)]
+      },
+      { logger },
+    )
+
+    expect(result.map((s) => s.title)).toEqual(['ok-1', 'ok-2'])
+  })
+
+  test('logs each failed page as a warning with the item and error', async () => {
+    const logger = makeLogger()
+    const error = new Error('network blip')
+
+    await extractScreeningsFromPages(
+      [{ url: 'https://example.com/boom' }],
+      async () => {
+        throw error
+      },
+      { logger },
+    )
+
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).toHaveBeenCalledWith(
+      'failed to extract screenings from page',
+      { item: { url: 'https://example.com/boom' }, error },
+    )
+  })
+
+  test('describe customizes what is logged for a failed item', async () => {
+    const logger = makeLogger()
+
+    await extractScreeningsFromPages(
+      [{ title: 'X', url: 'https://example.com/x' }],
+      async () => {
+        throw new Error('boom')
+      },
+      { logger, describe: (item) => item.url },
+    )
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'failed to extract screenings from page',
+      expect.objectContaining({ item: 'https://example.com/x' }),
+    )
+  })
+})

--- a/cloud/test/extractScreeningsFromPages.test.ts
+++ b/cloud/test/extractScreeningsFromPages.test.ts
@@ -42,12 +42,12 @@ describe('extractScreeningsFromPages', () => {
     expect(result.map((s) => s.title)).toEqual(['ok-1', 'ok-2'])
   })
 
-  test('logs each failed page as a warning with the item and error', async () => {
+  test('logs each failed page as a warning with the url and error', async () => {
     const logger = makeLogger()
     const error = new Error('network blip')
 
     await extractScreeningsFromPages(
-      [{ url: 'https://example.com/boom' }],
+      ['https://example.com/boom'],
       async () => {
         throw error
       },
@@ -57,11 +57,11 @@ describe('extractScreeningsFromPages', () => {
     expect(logger.warn).toHaveBeenCalledTimes(1)
     expect(logger.warn).toHaveBeenCalledWith(
       'failed to extract screenings from page',
-      { item: { url: 'https://example.com/boom' }, error },
+      { url: 'https://example.com/boom', error },
     )
   })
 
-  test('describe customizes what is logged for a failed item', async () => {
+  test('url selector extracts the page url from an object item', async () => {
     const logger = makeLogger()
 
     await extractScreeningsFromPages(
@@ -69,12 +69,12 @@ describe('extractScreeningsFromPages', () => {
       async () => {
         throw new Error('boom')
       },
-      { logger, describe: (item) => item.url },
+      { logger, url: (item) => item.url },
     )
 
     expect(logger.warn).toHaveBeenCalledWith(
       'failed to extract screenings from page',
-      expect.objectContaining({ item: 'https://example.com/x' }),
+      expect.objectContaining({ url: 'https://example.com/x' }),
     )
   })
 })


### PR DESCRIPTION
## Problem

Scrapers that fan out over detail pages use the fail-fast pattern:

```ts
const screenings = (await Promise.all(list.map(extractFromMoviePage))).flat()
```

`Promise.all` rejects the **whole batch** if **any one** of the (often ~70) per-film-page fetches rejects — a transient network/site blip, a timeout, one oddly-shaped page. When that happens the scraper throws, the orchestrator catches it and records `[]`, so **one flaky page zeroes out an entire cinema**.

### Evidence (filmhuislumen)

S3 run history (`s3://expatcinema-scrapers-output-prod/filmhuislumen/`) shows this in the wild. Isolated nights came back empty (2-byte `[]`) while the days around them — and every other scraper on those same nights — were fine:

| Date | Result |
|------|--------|
| 2026-05-29 Fri | ✅ |
| 2026-05-30 Sat | ❌ empty |
| 2026-05-31 Sun | ❌ empty |
| 2026-06-01 Mon | ✅ |
| 2026-06-05 Fri | ✅ |
| 2026-06-06 Sat | ❌ empty |
| 2026-06-07 Sun | ❌ empty |
| 2026-06-08 Mon | ✅ |

Across all history ~14% of filmhuislumen runs were empty — the chronic signature of this fail-fast design.

## Fix

New shared helper `scrapers/utils/extractScreeningsFromPages.ts`, built on `Promise.allSettled`:

- runs the per-page extractor over every item,
- logs each **rejected** page as a `warn` (with the item + error),
- returns the flattened screenings from the pages that **succeeded**.

A single failing film page can no longer zero out a cinema; it just drops that one page and logs a warning.

### Designed for a future per-page `pRetry`

The helper calls the extractor once per item on a single marked line — that's the seam to wrap with `pRetry` later, without touching any call site.

## Scope

Migrated the **16 identical-shape** scrapers onto the helper: filmhuislumen, heerenstraattheater, fchyena, forumgroningen, focusarnhem, cinemadevlugt, dewittdordrecht, natlab, lantarenvenster, worm, hetdocumentairepaviljoen, deuitkijk, dokhuis, lux, rialto, lumiere.

Out of scope for this PR:
- **melkweg** — extractor returns `Screening | null` (different shape)
- **lab1, lab111, filmhuisdenhaag, sliekerfilm** — irregular shapes
- **ketelhuis, studiok** — already use `pRetry` (still fail-fast on exhaustion; follow-up)

## Testing

- `pnpm type-check` ✅
- `pnpm test` ✅ (72 tests, incl. 4 new helper unit tests covering flatten, one-page-failure isolation, and warn logging)
- Ran live locally: filmhuislumen still returns 17 screenings (unchanged), rialto 27 — extraction intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)